### PR TITLE
Removed unnecessary JSON parses

### DIFF
--- a/examples/script/assert.http
+++ b/examples/script/assert.http
@@ -23,10 +23,8 @@ GET https://cat-fact.herokuapp.com/facts/random HTTP/1.1
         ok(response.body);
     });
 
-    var body = JSON.parse(response.body);
-
     test('type is cat', () => {
-        equal(body.type, 'cat');
+        equal(response.parsedBody.type, 'cat');
     });
 }}
 

--- a/examples/script/chai.http
+++ b/examples/script/chai.http
@@ -21,10 +21,8 @@ GET https://cat-fact.herokuapp.com/facts/random HTTP/1.1
       expect(response.body).to.not.be.null;
   });
 
-  var body = JSON.parse(response.body);
-
   test('type is cat', () => {
-      expect(body.type).to.equal('cat');
+      expect(response.parsedBody.type).to.equal('cat');
   });
 }}
 
@@ -43,14 +41,13 @@ GET https://cat-fact.herokuapp.com/facts/random HTTP/1.1
       expect(response.body).to.not.be.null;
   });
 
-  var body = JSON.parse(response.body);
 
   test('text equals hello world', () => {
-      expect(body.text).to.equal('hello world');
+      expect(response.parsedBody.text).to.equal('hello world');
   });
 
   test('type is cat', () => {
-      expect(body.type).to.equal('cat');
+      expect(response.parsedBody.type).to.equal('cat');
   });
 }}
 
@@ -65,10 +62,8 @@ GET https://cat-fact.herokuapp.com/facts/random HTTP/1.1
       expect(response.statusCode).to.equal(400);
   });
 
-  var body = JSON.parse(response.body);
-
   test('text equals hello world', () => {
-      expect(body.text).to.equal('hello world');
+      expect(response.parsedBody.text).to.equal('hello world');
   });
 }}
 


### PR DESCRIPTION
#### Reference issues
None

#### Explain your changes
The `JSON.parse(response.body)` is unnecessary since [httpResponse](https://github.com/AnWeber/httpyac/blob/main/src/models/httpResponse.ts) already contains the body as JSON.

#### Comments
This is my first contribution, so I am not sure I have done it right.