### PR TITLE
Use built-in base64 URL-safe buffer encoding

### DIFF
--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -94,23 +94,8 @@ export function decodeJWT(str: string): JWTToken | null {
     if (jwtComponents.length !== 3) {
       return null;
     }
-    let payload = jwtComponents[1];
-    payload = payload.replace(/-/gu, '+');
-    payload = payload.replace(/_/gu, '/');
-    switch (payload.length % 4) {
-      case 0:
-        break;
-      case 2:
-        payload += '==';
-        break;
-      case 3:
-        payload += '=';
-        break;
-      default:
-        return null;
-    }
-
-    const result = decodeURIComponent(escape(Buffer.from(payload, 'base64').toString()));
+    const payload = jwtComponents[1];
+    const result = Buffer.from(payload, 'base64url').toString();
 
     return JSON.parse(result);
   } catch (err) {

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -4,6 +4,7 @@ import { isMimeTypeJSON, isMimeTypeXml, parseMimeType } from './mimeTypeUtils';
 import { default as chalk } from 'chalk';
 import { log } from '../io';
 import xmlFormat from 'xml-formatter';
+import { TextDecoder } from 'util';
 
 
 export function isHttpRequestMethod(method: string | undefined): method is models.HttpMethod {
@@ -110,8 +111,7 @@ export function decodeJWT(str: string): JWTToken | null {
         return null;
     }
 
-    const result = Buffer.from(payload, 'base64').toString();
-
+    const result = (new TextDecoder()).decode(Buffer.from(payload, 'base64'));
     return JSON.parse(result);
   } catch (err) {
     log.warn(err);

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -94,8 +94,23 @@ export function decodeJWT(str: string): JWTToken | null {
     if (jwtComponents.length !== 3) {
       return null;
     }
-    const payload = jwtComponents[1];
-    const result = Buffer.from(payload, 'base64url').toString();
+    let payload = jwtComponents[1];
+    payload = payload.replace(/-/gu, '+');
+    payload = payload.replace(/_/gu, '/');
+    switch (payload.length % 4) {
+      case 0:
+        break;
+      case 2:
+        payload += '==';
+        break;
+      case 3:
+        payload += '=';
+        break;
+      default:
+        return null;
+    }
+
+    const result = Buffer.from(payload, 'base64').toString();
 
     return JSON.parse(result);
   } catch (err) {


### PR DESCRIPTION
When decoding access tokens we should use the built-in encoding `base64url` instead of trying to do our own base64-URL-safe decoding.

The existing code throws `URIError: URI malformed` for perfectly valid access tokens issued by Microsoft IDP. The proposed change now decodes these access tokens without error.