### PR TITLE
Make refresh token expiration optional

### DIFF
--- a/src/variables/replacer/oauth/refreshTokenFlow.ts
+++ b/src/variables/replacer/oauth/refreshTokenFlow.ts
@@ -13,8 +13,11 @@ class RefreshTokenFlow {
       return openIdInformation;
     }
     if (openIdInformation.refreshToken
-      && openIdInformation.refreshExpiresIn
-      && !this.isTokenExpired(openIdInformation.time, openIdInformation.refreshExpiresIn, openIdInformation.timeSkew)) {
+      && (
+        typeof openIdInformation.refreshExpiresIn !== 'undefined'
+          ? !this.isTokenExpired(openIdInformation.time, openIdInformation.refreshExpiresIn, openIdInformation.timeSkew)
+          : true
+      )) {
       utils.report(context, 'execute OAuth2 refresh_token flow');
       return requestOpenIdInformation({
         url: openIdInformation.config.tokenEndpoint,

--- a/src/variables/replacer/oauth/refreshTokenFlow.ts
+++ b/src/variables/replacer/oauth/refreshTokenFlow.ts
@@ -4,20 +4,19 @@ import { OpenIdFlowContext } from './openIdFlow';
 
 class RefreshTokenFlow {
 
-  private isTokenExpired(time: number, expiresIn: number, timeSkew: number) {
-    return time + 1000 * (expiresIn - timeSkew) < (new Date()).getTime();
+  private isTokenExpired(time: number, timeSkew: number, expiresIn?: number) {
+    if (typeof expiresIn !== 'undefined') {
+      return time + 1000 * (expiresIn - timeSkew) < (new Date()).getTime();
+    }
+    return false;
   }
 
   async perform(openIdInformation: OpenIdInformation, context: OpenIdFlowContext): Promise<OpenIdInformation | false> {
-    if (!this.isTokenExpired(openIdInformation.time, openIdInformation.expiresIn, openIdInformation.timeSkew)) {
+    if (!this.isTokenExpired(openIdInformation.time, openIdInformation.timeSkew, openIdInformation.expiresIn)) {
       return openIdInformation;
     }
     if (openIdInformation.refreshToken
-      && (
-        typeof openIdInformation.refreshExpiresIn !== 'undefined'
-          ? !this.isTokenExpired(openIdInformation.time, openIdInformation.refreshExpiresIn, openIdInformation.timeSkew)
-          : true
-      )) {
+      && !this.isTokenExpired(openIdInformation.time, openIdInformation.timeSkew, openIdInformation.refreshExpiresIn)) {
       utils.report(context, 'execute OAuth2 refresh_token flow');
       return requestOpenIdInformation({
         url: openIdInformation.config.tokenEndpoint,


### PR DESCRIPTION
When a OAuth2 token redemption request succeeds and provides a `refresh_token`, but does not provide an expiration for the refresh token, subsequent uses of the oauth2 session (after the initial `access_token` has expired) will trigger a full re-authentication as the `RefreshTokenFlow.perform` method requires the `refreshExpiresIn` to be defined on the OpenID information object.

This proposal relaxes this requirement to be more inline with the OAuth2 specification and the type definition of the `OpenIdInformation` interface who both state this property to be optional.

In this proposal, if a `refresh_token` is available, but no expiration is defined, the `RefreshTokenFlow.perform` will attempt to refresh.