### PR TITLE
fix: blank header value caused request failure

### DIFF
--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -44,7 +44,7 @@ export function parseSubsequentLines(
 export function parseRequestHeaderFactory(headers: Record<string, unknown>): ParseLineMethod {
   return function parseRequestHeader(httpLine: models.HttpLine) {
     const headerMatch = ParserRegex.request.header.exec(httpLine.textLine);
-    if (headerMatch?.groups?.key && headerMatch?.groups?.value) {
+    if (headerMatch?.groups?.key) {
       const headerName = headerMatch.groups.key;
       const headerValue = headerMatch.groups.value;
 


### PR DESCRIPTION
Blank header field caused header parsing failure. As a result, the subsequent header section would be mistaken as request body. Minimal example:
```
###
POST https://httpbin.org/anything
user-abi: 
user-token: 1234567
```
