### PR TITLE
Configure callback

### DIFF
--- a/src/cli/cliOptions.ts
+++ b/src/cli/cliOptions.ts
@@ -27,7 +27,6 @@ export interface CliOptions {
   variables?: Array<string>;
   verbose?: boolean;
   version?: boolean;
-  authCallback?: string;
 }
 
 export function getLogLevel(cliOptions: CliOptions): LogLevel | undefined {
@@ -48,7 +47,6 @@ export function parseCliOptions(rawArgs: string[]): CliOptions | undefined {
     const args = arg(
       {
         '--all': Boolean,
-        '--auth-callback': String,
         '--bail': Boolean,
         '--editor': Boolean,
         '--env': [String],
@@ -89,7 +87,6 @@ export function parseCliOptions(rawArgs: string[]): CliOptions | undefined {
     return {
       activeEnvironments: args['--env'],
       allRegions: args['--all'],
-      authCallback: args['--auth-callback'],
       bail: args['--bail'],
       editor: args['--editor'],
       fileName: args._.length > 0 ? args._[args._.length - 1] : undefined,
@@ -130,7 +127,6 @@ export function renderHelp(): void {
 
 usage: httpyac [options...] <file or glob pattern>
        --all           execute all http requests in a http file
-       --auth-callback auth callback url (default: http://localhost:3000/callback)
        --bail          stops when a test case fails
        --editor        enter a new request and execute it
   -e   --env           list of environments

--- a/src/cli/cliOptions.ts
+++ b/src/cli/cliOptions.ts
@@ -27,6 +27,7 @@ export interface CliOptions {
   variables?: Array<string>;
   verbose?: boolean;
   version?: boolean;
+  authCallback?: string;
 }
 
 export function getLogLevel(cliOptions: CliOptions): LogLevel | undefined {
@@ -47,6 +48,7 @@ export function parseCliOptions(rawArgs: string[]): CliOptions | undefined {
     const args = arg(
       {
         '--all': Boolean,
+        '--auth-callback': String,
         '--bail': Boolean,
         '--editor': Boolean,
         '--env': [String],
@@ -87,6 +89,7 @@ export function parseCliOptions(rawArgs: string[]): CliOptions | undefined {
     return {
       activeEnvironments: args['--env'],
       allRegions: args['--all'],
+      authCallback: args['--auth-callback'],
       bail: args['--bail'],
       editor: args['--editor'],
       fileName: args._.length > 0 ? args._[args._.length - 1] : undefined,
@@ -127,6 +130,7 @@ export function renderHelp(): void {
 
 usage: httpyac [options...] <file or glob pattern>
        --all           execute all http requests in a http file
+       --auth-callback auth callback url (default: http://localhost:3000/callback)
        --bail          stops when a test case fails
        --editor        enter a new request and execute it
   -e   --env           list of environments

--- a/src/variables/replacer/oauth/authorizationCodeFlow.ts
+++ b/src/variables/replacer/oauth/authorizationCodeFlow.ts
@@ -4,7 +4,6 @@ import { OpenIdFlow, OpenIdFlowContext } from './openIdFlow';
 import { registerListener, unregisterListener } from './openIdHttpserver';
 import { OpenIdInformation, requestOpenIdInformation } from './openIdInformation';
 import open from 'open';
-import { URL } from 'url';
 
 class AuthorizationCodeFlow implements OpenIdFlow {
   supportsFlow(flow: string): boolean {
@@ -25,7 +24,6 @@ class AuthorizationCodeFlow implements OpenIdFlow {
         const state = utils.stateGenerator();
         try {
           utils.report(context, 'execute OAuth2 authorization_code flow');
-          const redirectUri = new URL(config.redirectUri);
           const authUrl = `${config.authorizationEndpoint}${
             config.authorizationEndpoint.indexOf('?') > 0 ? '&' : '?'
           }${utils.toQueryParams({
@@ -34,7 +32,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
             response_type: 'code',
             state,
             audience: config.audience,
-            redirect_uri: redirectUri.toString(),
+            redirect_uri: config.redirectUri.toString(),
           })}`;
 
           let unregisterProgress: (() => void) | undefined;
@@ -47,7 +45,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
 
           registerListener({
             id: state,
-            url: redirectUri,
+            url: config.redirectUri,
             name: `authorization for ${config.clientId}: ${config.authorizationEndpoint}`,
             resolve: params => {
               if (params.code && params.state === state) {
@@ -62,7 +60,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
                       grant_type: 'authorization_code',
                       scope: config.scope,
                       code: params.code,
-                      redirect_uri: redirectUri.toString(),
+                      redirect_uri: config.redirectUri.toString(),
                     }),
                   },
                   {

--- a/src/variables/replacer/oauth/authorizationCodeFlow.ts
+++ b/src/variables/replacer/oauth/authorizationCodeFlow.ts
@@ -4,6 +4,7 @@ import { OpenIdFlow, OpenIdFlowContext } from './openIdFlow';
 import { registerListener, unregisterListener } from './openIdHttpserver';
 import { OpenIdInformation, requestOpenIdInformation } from './openIdInformation';
 import open from 'open';
+import { URL } from 'url';
 
 class AuthorizationCodeFlow implements OpenIdFlow {
   supportsFlow(flow: string): boolean {
@@ -24,7 +25,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
         const state = utils.stateGenerator();
         try {
           utils.report(context, 'execute OAuth2 authorization_code flow');
-          const redirectUri = 'http://localhost:3000/callback';
+          const redirectUri = new URL(config.redirectUri);
           const authUrl = `${config.authorizationEndpoint}${
             config.authorizationEndpoint.indexOf('?') > 0 ? '&' : '?'
           }${utils.toQueryParams({
@@ -33,7 +34,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
             response_type: 'code',
             state,
             audience: config.audience,
-            redirect_uri: redirectUri,
+            redirect_uri: redirectUri.toString(),
           })}`;
 
           let unregisterProgress: (() => void) | undefined;
@@ -46,6 +47,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
 
           registerListener({
             id: state,
+            url: redirectUri,
             name: `authorization for ${config.clientId}: ${config.authorizationEndpoint}`,
             resolve: params => {
               if (params.code && params.state === state) {
@@ -60,7 +62,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
                       grant_type: 'authorization_code',
                       scope: config.scope,
                       code: params.code,
-                      redirect_uri: redirectUri,
+                      redirect_uri: redirectUri.toString(),
                     }),
                   },
                   {

--- a/src/variables/replacer/oauth/implicitFlow.ts
+++ b/src/variables/replacer/oauth/implicitFlow.ts
@@ -5,7 +5,6 @@ import { OpenIdFlow, OpenIdFlowContext } from './openIdFlow';
 import { registerListener, unregisterListener } from './openIdHttpserver';
 import { OpenIdInformation, toOpenIdInformation, requestOpenIdInformation } from './openIdInformation';
 import open from 'open';
-import { URL } from 'url';
 
 class ImplicitFlow implements OpenIdFlow {
   supportsFlow(flow: string): boolean {
@@ -36,7 +35,7 @@ class ImplicitFlow implements OpenIdFlow {
             state,
             response_mode: config.responseMode,
             audience: config.audience,
-            redirect_uri: config.redirectUri,
+            redirect_uri: config.redirectUri.toString(),
           })}`;
 
           let unregisterProgress: (() => void) | undefined;
@@ -47,11 +46,9 @@ class ImplicitFlow implements OpenIdFlow {
             });
           }
 
-          const redirectUri = new URL(config.redirectUri);
-
           registerListener({
             id: state,
-            url: redirectUri,
+            url: config.redirectUri,
             name: `authorization for ${config.clientId}: ${config.authorizationEndpoint}`,
             resolve: params => {
               if (params.state === state) {
@@ -64,7 +61,7 @@ class ImplicitFlow implements OpenIdFlow {
                         grant_type: 'authorization_code',
                         scope: config.scope,
                         code: params.code,
-                        redirect_uri: redirectUri.toString(),
+                        redirect_uri: config.redirectUri.toString(),
                       }),
                     },
                     {

--- a/src/variables/replacer/oauth/openIdConfiguration.ts
+++ b/src/variables/replacer/oauth/openIdConfiguration.ts
@@ -2,6 +2,7 @@ import { log, userInteractionProvider } from '../../../io';
 import { Variables } from '../../../models';
 import get from 'lodash/get';
 
+const DEFAULT_CALLBACK_URI = 'http://localhost:3000/callback';
 export interface OpenIdConfiguration {
   variablePrefix: string;
   authorizationEndpoint: string;
@@ -18,6 +19,7 @@ export interface OpenIdConfiguration {
   password?: string;
   subjectIssuer?: string;
   useAuthorizationHeader: boolean;
+  redirectUri: string;
 }
 
 function getVariable(variables: Variables, variablePrefix: string, name: string): string {
@@ -40,6 +42,7 @@ export function getOpenIdConfiguration(variablePrefix: string, variables: Variab
       username: getVariable(variables, variablePrefix, 'username'),
       password: getVariable(variables, variablePrefix, 'password'),
       subjectIssuer: getVariable(variables, variablePrefix, 'subjectIssuer'),
+      redirectUri: getVariable(variables, variablePrefix, 'redirectUri') || DEFAULT_CALLBACK_URI,
       keepAlive: ['true', '1', true].indexOf(getVariable(variables, variablePrefix, 'keepAlive')) < 0,
       useAuthorizationHeader:
         ['false', '0', false].indexOf(getVariable(variables, variablePrefix, 'useAuthorizationHeader')) < 0,

--- a/test/variables/replacer/oauth/openIdConfiguration.test.ts
+++ b/test/variables/replacer/oauth/openIdConfiguration.test.ts
@@ -1,0 +1,27 @@
+import {
+  getOpenIdConfiguration,
+  DEFAULT_CALLBACK_URI,
+  OpenIdConfiguration,
+} from '../../../../src/variables/replacer/oauth/openIdConfiguration';
+
+describe('getOpenIdConfiguration', () => {
+  describe('redirectUri', () => {
+    it('should default when nothing passed', () => {
+      const result = getOpenIdConfiguration('prefix', {}) as OpenIdConfiguration;
+      expect(result.redirectUri.toString()).toEqual(DEFAULT_CALLBACK_URI);
+    });
+
+    it('should throw on bad url', () => {
+      expect(() => getOpenIdConfiguration('prefix', { prefix_redirectUri: 'not-a-url' })).toThrow(
+        'Expected a valid URL, but received not-a-url'
+      );
+    });
+
+    it('should use valid url when passed', () => {
+      const result = getOpenIdConfiguration('prefix', {
+        prefix_redirectUri: 'http://my-url.com:1234',
+      }) as OpenIdConfiguration;
+      expect(result.redirectUri.toString()).toEqual('http://my-url.com:1234/');
+    });
+  });
+});


### PR DESCRIPTION
- solves #118 
- validates `redirectUri`

Uses existing `var` functionality

```bash
httpyac file.http --all --var oauth2_redirectUri=http://localhost:1234/some/path
```

or

```bash
httpyac file.http --all --var myPrefix_redirectUri=http://localhost:9000
```

or

```bash
# .env
oauth2_redirectUri=http://0.0.0.0:7000/callback
```

or

```bash
# file.http
@oauth2_redirectUri=http://whatever.com/
```