### PR TITLE
Implicit auth: Configure server to shutdown on token received

### DIFF
--- a/src/variables/replacer/oauth/implicitFlow.ts
+++ b/src/variables/replacer/oauth/implicitFlow.ts
@@ -48,6 +48,7 @@ class ImplicitFlow implements OpenIdFlow {
 
           registerListener({
             id: state,
+            shutdownOnTokenReceived: config.shutdownOnTokenReceived,
             url: config.redirectUri,
             name: `authorization for ${config.clientId}: ${config.authorizationEndpoint}`,
             resolve: params => {

--- a/src/variables/replacer/oauth/openIdConfiguration.ts
+++ b/src/variables/replacer/oauth/openIdConfiguration.ts
@@ -21,6 +21,7 @@ export interface OpenIdConfiguration {
   subjectIssuer?: string;
   useAuthorizationHeader: boolean;
   redirectUri: URL;
+  shutdownOnTokenReceived: boolean;
 }
 
 function getVariable(variables: Variables, variablePrefix: string, name: string): string {
@@ -54,6 +55,8 @@ export function getOpenIdConfiguration(variablePrefix: string, variables: Variab
       subjectIssuer: getVariable(variables, variablePrefix, 'subjectIssuer'),
       redirectUri: getUrl(variables, variablePrefix, 'redirectUri', DEFAULT_CALLBACK_URI),
       keepAlive: ['true', '1', true].indexOf(getVariable(variables, variablePrefix, 'keepAlive')) < 0,
+      shutdownOnTokenReceived:
+        ['false', '0', false].indexOf(getVariable(variables, variablePrefix, 'shutdownOnTokenReceived')) < 0,
       useAuthorizationHeader:
         ['false', '0', false].indexOf(getVariable(variables, variablePrefix, 'useAuthorizationHeader')) < 0,
     };


### PR DESCRIPTION
While investigating #138 I determined that calling the api directly would be a better approach for me.

This PR lets me close the server immediately on receipt of the token, so I can run code like this:

```javascript
const { variables, io } = require('httpyac');

const context = {
  variables: {
    oauth2_authorizationEndpoint:
		'https://login.microsoftonline.com/<tenantId>/oauth2/authorize?resource=<resourceId>',
    oauth2_clientId: '<clientId>',
    oauth2_tokenEndpoint: 'https://login.microsoftonline.com/<tenantId>/oauth2/v2.0/token',
    oauth2_redirectUri: 'http://localhost:3000/',
    oauth2_shutdownOnToken: true,
  },
  httpClient: io.initHttpClient({}),
};

variables.replacer.oauth2VariableReplacer('openid implicit', 'authorization', context)
	.then((auth) => console.log(auth.replace("Bearer ", ""));
```

