### PR TITLE
Add httpyac runtime reference to plugin api

### DIFF
--- a/src/models/httpHooksApi.ts
+++ b/src/models/httpHooksApi.ts
@@ -1,3 +1,4 @@
+import * as httpyac from '..';
 import { EnvironmentConfig } from './environmentConfig';
 import { FileProvider } from './fileProvider';
 import { HookCancel } from './hook';
@@ -10,6 +11,7 @@ import { UserInteractonProvider } from './userInteractonProvider';
 
 export interface HttpyacHooksApi {
   readonly version: string;
+  readonly httpyac: typeof httpyac;
   readonly rootDir?: PathLike;
   readonly httpFile: Readonly<HttpFile>;
   readonly config: EnvironmentConfig;

--- a/src/models/httpHooksApi.ts
+++ b/src/models/httpHooksApi.ts
@@ -1,4 +1,4 @@
-import * as httpyac from '..';
+import * as utils from '../utils';
 import { EnvironmentConfig } from './environmentConfig';
 import { FileProvider } from './fileProvider';
 import { HookCancel } from './hook';
@@ -11,7 +11,6 @@ import { UserInteractonProvider } from './userInteractonProvider';
 
 export interface HttpyacHooksApi {
   readonly version: string;
-  readonly httpyac: typeof httpyac;
   readonly rootDir?: PathLike;
   readonly httpFile: Readonly<HttpFile>;
   readonly config: EnvironmentConfig;
@@ -20,5 +19,6 @@ export interface HttpyacHooksApi {
   readonly fileProvider: FileProvider;
   readonly sessionStore: SessionStore;
   readonly userInteractionProvider: UserInteractonProvider;
+  readonly utils: typeof utils;
   getHookCancel(): typeof HookCancel;
 }

--- a/src/store/httpFileStore.ts
+++ b/src/store/httpFileStore.ts
@@ -1,3 +1,4 @@
+import * as httpyac from '..';
 import { initOnRequestHook, initOnResponseHook } from '../actions';
 import { fileProvider, log, userInteractionProvider } from '../io';
 import * as models from '../models';
@@ -184,6 +185,7 @@ export class HttpFileStore {
     if (options.config) {
       const api: models.HttpyacHooksApi = {
         version: '1.0.0',
+        httpyac,
         rootDir: httpFile.rootDir,
         config: options.config,
         httpFile,

--- a/src/store/httpFileStore.ts
+++ b/src/store/httpFileStore.ts
@@ -1,4 +1,3 @@
-import * as httpyac from '..';
 import { initOnRequestHook, initOnResponseHook } from '../actions';
 import { fileProvider, log, userInteractionProvider } from '../io';
 import * as models from '../models';
@@ -185,7 +184,6 @@ export class HttpFileStore {
     if (options.config) {
       const api: models.HttpyacHooksApi = {
         version: '1.0.0',
-        httpyac,
         rootDir: httpFile.rootDir,
         config: options.config,
         httpFile,
@@ -194,6 +192,7 @@ export class HttpFileStore {
         fileProvider,
         sessionStore,
         userInteractionProvider,
+        utils,
         getHookCancel: () => HookCancel,
       };
       for (const [plugin, hook] of Object.entries(hooks)) {


### PR DESCRIPTION
~~Adds a new property `httpyac` to the `HttpyacHooksApi` type.~~

Adds a new property `utils` to the to the `HttpyacHooksApi` type.

This will enable a plugin or a `configureHooks` function provided by `.httpyac.js` to use the exported functions in the `httpyac` module from memory without the need of resolving/requiring the module.

This has the benefit that a no-dependencies plugin or a standalone `.httpyac.js` can run in the context of httpyac without any additional steps. It will also ensure that a plugin *sees* the same APIs as the runtime it is extending. Typically a plugin could now only add a `devDependency` on `httpyac` to get type definitions, but the original way of doing thing would still work seamlessly (you'd just ignore the new property).

