### PR TITLE
Add rawHeaders to HttpResponse

### DIFF
--- a/src/cli/send/jsonOutput.ts
+++ b/src/cli/send/jsonOutput.ts
@@ -85,6 +85,7 @@ export function toSendJsonOutput(context: Record<string, Array<HttpRegion>>, opt
 
 function convertResponse(response: HttpResponse | undefined, output: string | undefined) {
   if (response) {
+    delete response.rawHeaders;
     delete response.rawBody;
     delete response.prettyPrintBody;
     delete response.parsedBody;

--- a/src/models/httpResponse.ts
+++ b/src/models/httpResponse.ts
@@ -12,6 +12,7 @@ export interface HttpResponse {
   body?: unknown;
   parsedBody?: unknown;
   prettyPrintBody?: string;
+  rawHeaders?: string[];
   rawBody?: Buffer;
   request?: Request;
 

--- a/src/utils/gotUtils.ts
+++ b/src/utils/gotUtils.ts
@@ -119,6 +119,7 @@ function toHttpResponse(response: Response<unknown>): HttpResponse {
     protocol: `HTTP/${response.httpVersion}`,
     statusMessage: response.statusMessage,
     body: response.body,
+    rawHeaders: response.rawHeaders,
     rawBody: response.rawBody,
     headers: response.headers,
     timings: response.timings.phases,
@@ -163,4 +164,26 @@ export function initHttpClient(content: { config?: EnvironmentConfig }): HttpCli
     proxy: content.config?.proxy,
   };
   return gotHttpClientFactory(request);
+}
+
+/**
+ * Merges a raw HTTP headers array from a got HTTP Response into a record that
+ * groups same-named lower-cased HTTP Headers to arrays of values.
+ * I.e. HTTP headers that only appear once will be associated with a single-item string-array,
+ * Headers that appear multiple times (e.g. Set-Cookie) are stored in multi-item string-arrays in order of appearence.
+ * @param rawHeaders A raw HTTP headers array, even numbered indicies represent HTTP header names, odd numbered indicies represent header values.
+ */
+export function mergeRawHttpHeaders(rawHeaders: string[]): Record<string, string[]> {
+  const mergedHeaders: Record<string, string[]> = {};
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    const headerRawName = rawHeaders[i];
+    const headerRawValue = rawHeaders[i + 1];
+    if (typeof headerRawValue === 'undefined') {
+      continue; // Likely at end of array, continue will make for-condition to evaluate falsy
+    }
+    const headerName = headerRawName.toLowerCase();
+    mergedHeaders[headerName] ||= [];
+    mergedHeaders[headerName].push(headerRawValue);
+  }
+  return mergedHeaders;
 }

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -287,6 +287,7 @@ export function cloneResponse(response: models.HttpResponse): models.HttpRespons
     httpVersion: response.httpVersion,
     headers: response.headers,
     body: response.body,
+    rawHeaders: response.rawHeaders,
     rawBody: response.rawBody,
     parsedBody: response.parsedBody,
     prettyPrintBody: response.prettyPrintBody,

--- a/test/utils/gotUtils.test.ts
+++ b/test/utils/gotUtils.test.ts
@@ -1,0 +1,23 @@
+import { mergeRawHttpHeaders } from '../../src/utils/gotUtils';
+
+describe('Raw HTTP Header merge utils', () => {
+  it('merges example raw headers to expected record value', () => {
+    // Example taken from got documentation of the rawHeaders property of the Response type
+    const rawHeaders = [
+      'user-agent',
+      'this is invalid because there can be only one',
+      'User-Agent',
+      'curl/7.22.0',
+      'Host',
+      '127.0.0.1:8000',
+      'ACCEPT',
+      '*',
+    ];
+    const mergedHeaders = mergeRawHttpHeaders(rawHeaders);
+    // Note User-Agent header with different casing collapsed into a single multi-item string-array
+    expect(mergedHeaders['user-agent']).toEqual(['this is invalid because there can be only one', 'curl/7.22.0']);
+    // Headers that only appear once are stored in single-item string-arrays
+    expect(mergedHeaders.host).toEqual(['127.0.0.1:8000']);
+    expect(mergedHeaders.accept).toEqual(['*']);
+  });
+});


### PR DESCRIPTION
As per the documentation from node.js (which is also used by got), HTTP headers from the response are (in most cases) merged together by joining multiple values from equal-named headers with `', '`. (I.e. multiple x-some-header headers are combined to one header value with `<value1>, <value2>, etc.`).

In most cases that is fine as there is some special handling for some default headers (e.g. `User-Agent` (multiple values are discarded) and `Set-Cookie` (value is always an array).

However, I find myself in a situation where I need to handle multiple values for a header. And to makes matters even worse, I need to parse these headers and the syntax I am parsing contains `,`. In such a case the intelligent header handling of got is not helpful.

For such purposes I propose that we add a new property `rawHeaders` to the `HttpResponse` type which is populated from the same-named property from the got Response object.

Because the got raw-headers are a little cumbersome to work with, I propose to also add a merging helper function that combines equal named headers into arrays and group them by lower-cased header names. That way you can easily get the best of both worlds with little effort (i.e. simply pass the raw-headers into the helper function), while not requiring extra work to be done if you don't need it (`rawHeaders` is already accessible in the got HTTP Response object).