### PR TITLE
 support absolute path as uri

### DIFF
--- a/src/parser/requestHttpRegionParser.ts
+++ b/src/parser/requestHttpRegionParser.ts
@@ -69,6 +69,14 @@ export async function parseRequestLine(
         context.httpRegion.request.contentType = utils.parseMimeType(contentType);
       }
     }
+
+    const host = utils.getHeader(request.headers, 'Host');
+    if (utils.isString(host) && request.url?.startsWith('/')) {
+        const [, port] = host.toString().split(':');
+        const scheme = port === '443' || port === '8443' ? 'https' : 'http';
+        request.url = `${scheme}://${host}${request.url}`;
+    }
+  
     return result;
   }
   return false;

--- a/src/parser/requestHttpRegionParser.ts
+++ b/src/parser/requestHttpRegionParser.ts
@@ -69,14 +69,6 @@ export async function parseRequestLine(
         context.httpRegion.request.contentType = utils.parseMimeType(contentType);
       }
     }
-
-    const host = utils.getHeader(request.headers, 'Host');
-    if (utils.isString(host) && request.url?.startsWith('/')) {
-        const [, port] = host.toString().split(':');
-        const scheme = port === '443' || port === '8443' ? 'https' : 'http';
-        request.url = `${scheme}://${host}${request.url}`;
-    }
-  
     return result;
   }
   return false;

--- a/src/variables/replacer/hostVariableReplacer.ts
+++ b/src/variables/replacer/hostVariableReplacer.ts
@@ -1,14 +1,22 @@
 import { ProcessorContext, VariableType } from '../../models';
-import { isString } from '../../utils';
+import * as utils from '../../utils';
 
 export async function hostVariableReplacer(
   text: unknown,
   type: VariableType | string,
-  { variables }: ProcessorContext
+  { variables, request }: ProcessorContext
 ): Promise<unknown> {
-  if (isString(text) && VariableType.url === type && !!variables.host) {
+  if (utils.isString(text) && VariableType.url === type) {
     if (text.startsWith('/')) {
-      return `${variables.host}${text}`;
+      if (variables.host) {
+        return `${variables.host}${text}`;
+      }
+      const host = utils.getHeader(request?.headers, 'Host');
+      if (utils.isString(host)) {
+        const [, port] = host.toString().split(':');
+        const scheme = port === '443' || port === '8443' ? 'https' : 'http';
+        return `${scheme}://${host}${text}`;
+      }
     }
   }
   return text;


### PR DESCRIPTION
support absolution path as uri, e.g.
```
GET /get HTTP/1.1
Host: httpbin.org
```
see [RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html)
