### PR TITLE
Add oauth2 variable prefix to cache key

### DIFF
--- a/src/plugins/oauth2/flow/authorizationCodeFlow.ts
+++ b/src/plugins/oauth2/flow/authorizationCodeFlow.ts
@@ -13,7 +13,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
 
   getCacheKey(config: models.OpenIdConfiguration) {
     if (assertConfiguration(config, ['tokenEndpoint', 'authorizationEndpoint', 'clientId', 'clientSecret'])) {
-      return `authorization_code_${config.clientId}_${config.tokenEndpoint}`;
+      return `authorization_code_${config.variablePrefix}_${config.clientId}_${config.tokenEndpoint}`;
     }
     return false;
   }

--- a/src/plugins/oauth2/flow/clientCredentialsFlow.ts
+++ b/src/plugins/oauth2/flow/clientCredentialsFlow.ts
@@ -11,7 +11,7 @@ class ClientCredentialsFlow implements OpenIdFlow {
 
   getCacheKey(config: models.OpenIdConfiguration) {
     if (assertConfiguration(config, ['tokenEndpoint', 'clientId', 'clientSecret'])) {
-      return `client_credentials_${config.clientId}_${config.tokenEndpoint}`;
+      return `client_credentials_${config.variablePrefix}_${config.clientId}_${config.tokenEndpoint}`;
     }
     return false;
   }

--- a/src/plugins/oauth2/flow/deviceCodeFlow.ts
+++ b/src/plugins/oauth2/flow/deviceCodeFlow.ts
@@ -13,7 +13,7 @@ class DeviceCodeFlow implements OpenIdFlow {
 
   getCacheKey(config: models.OpenIdConfiguration) {
     if (assertConfiguration(config, ['tokenEndpoint', 'deviceCodeEndpoint', 'clientId'])) {
-      return `device_code_${config.clientId}_${config.tokenEndpoint}`;
+      return `device_code_${config.variablePrefix}_${config.clientId}_${config.tokenEndpoint}`;
     }
     return false;
   }

--- a/src/plugins/oauth2/flow/implicitFlow.ts
+++ b/src/plugins/oauth2/flow/implicitFlow.ts
@@ -14,7 +14,7 @@ class ImplicitFlow implements OpenIdFlow {
 
   getCacheKey(config: models.OpenIdConfiguration) {
     if (assertConfiguration(config, ['tokenEndpoint', 'authorizationEndpoint', 'clientId'])) {
-      return `implicit_${config.clientId}_${config.tokenEndpoint}`;
+      return `implicit_${config.variablePrefix}_${config.clientId}_${config.tokenEndpoint}`;
     }
     return false;
   }

--- a/src/plugins/oauth2/flow/passwordFlow.ts
+++ b/src/plugins/oauth2/flow/passwordFlow.ts
@@ -11,7 +11,7 @@ class PasswordFlow implements OpenIdFlow {
 
   getCacheKey(config: models.OpenIdConfiguration) {
     if (assertConfiguration(config, ['tokenEndpoint', 'clientId', 'clientSecret', 'username', 'password'])) {
-      return `password_${config.clientId}_${config.username}_${config.tokenEndpoint}`;
+      return `password_${config.variablePrefix}_${config.clientId}_${config.username}_${config.tokenEndpoint}`;
     }
     return false;
   }


### PR DESCRIPTION
When you have multiple active oauth2 sessions that use different services from the same token authority the cache key of the oauth2 session overlaps. This forces a re-authentication and is very annoying.

I propose that the variable prefix is included in the cache key so that oauth2 sessions are kept seperate.

Example:

I have scenarios where I authenticate to multiple M365/Azure AD services, notably SharePoint and Microsoft Graph. Both are authorized by the Microsoft Identity platform token service, meaning the clientId and the tokenEndpoint is the same, but I have different scopes and therefore different variable prefixes. There are also other scenarios where I'd want to test access to an API with two different users in which case I'd have two prefixes, but all other variables would be the same.