### PR TITLE
OAuth2 allow usage of public clients

### DIFF
--- a/src/plugins/oauth2/flow/authorizationCodeFlow.ts
+++ b/src/plugins/oauth2/flow/authorizationCodeFlow.ts
@@ -12,7 +12,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
   }
 
   getCacheKey(config: models.OpenIdConfiguration) {
-    if (assertConfiguration(config, ['tokenEndpoint', 'authorizationEndpoint', 'clientId', 'clientSecret'])) {
+    if (assertConfiguration(config, ['tokenEndpoint', 'authorizationEndpoint', 'clientId'])) {
       return `authorization_code_${config.variablePrefix}_${config.clientId}_${config.tokenEndpoint}`;
     }
     return false;

--- a/src/plugins/oauth2/flow/passwordFlow.ts
+++ b/src/plugins/oauth2/flow/passwordFlow.ts
@@ -10,7 +10,7 @@ class PasswordFlow implements OpenIdFlow {
   }
 
   getCacheKey(config: models.OpenIdConfiguration) {
-    if (assertConfiguration(config, ['tokenEndpoint', 'clientId', 'clientSecret', 'username', 'password'])) {
+    if (assertConfiguration(config, ['tokenEndpoint', 'clientId', 'username', 'password'])) {
       return `password_${config.variablePrefix}_${config.clientId}_${config.username}_${config.tokenEndpoint}`;
     }
     return false;

--- a/src/plugins/oauth2/flow/requestOpenIdInformation.ts
+++ b/src/plugins/oauth2/flow/requestOpenIdInformation.ts
@@ -17,7 +17,10 @@ export async function requestOpenIdInformation(
       };
     }
 
-    if (request.headers && options.config.useAuthorizationHeader) {
+    if (
+      request.headers && options.config.useAuthorizationHeader
+      && options.config.clientId && options.config.clientSecret
+    ) {
       request.headers.authorization = `Basic ${Buffer.from(
         `${options.config.clientId}:${options.config.clientSecret}`
       ).toString('base64')}`;


### PR DESCRIPTION
According to OAuth2 specifications both the ROPC and authorization code grant flows can be used with public clients (clients without a secret). This PR relaxes the requirements that a clientSecret needs to be specified when using these flows.

Also when issueing a request to the token endpoint, the Authorization header with basic credentials (using client id and secret) should only be used when both client Id and client secret values are set (in addition to the `useAuthorizationHeader` config variable). As per OAuth specification, the Authorization header must not be used with a public client (i.e. when the client secret is not specified).

### Examples

The Microsoft Identity platform allows for public clients in all of their OAuth2 flows and instead allow for configuration when the OAuth2 is registered whether authorization using public clients is permissable.

When using a public client the Microsoft Identity platform fails the authorization when the authorization header is used.