### PR TITLE
Add optional OAuth2 resource parameters

### DIFF
--- a/src/models/openIdInformation.ts
+++ b/src/models/openIdInformation.ts
@@ -13,6 +13,7 @@ export interface OpenIdConfiguration {
   responseType: string;
   responseMode?: string;
   audience?: string;
+  resource?: string;
   scope: string;
   keepAlive: boolean;
   username?: string;

--- a/src/plugins/oauth2/flow/authorizationCodeFlow.ts
+++ b/src/plugins/oauth2/flow/authorizationCodeFlow.ts
@@ -36,6 +36,7 @@ class AuthorizationCodeFlow implements OpenIdFlow {
             response_type: 'code',
             state,
             audience: config.audience,
+            resource: config.resource,
             redirect_uri: config.redirectUri.toString(),
           })}`;
 

--- a/src/plugins/oauth2/flow/clientCredentialsFlow.ts
+++ b/src/plugins/oauth2/flow/clientCredentialsFlow.ts
@@ -30,6 +30,8 @@ class ClientCredentialsFlow implements OpenIdFlow {
           body: utils.toQueryParams({
             grant_type: 'client_credentials',
             scope: config.scope,
+            audience: config.audience,
+            resource: config.resource,
           }),
         },
         {

--- a/src/plugins/oauth2/flow/deviceCodeFlow.ts
+++ b/src/plugins/oauth2/flow/deviceCodeFlow.ts
@@ -154,6 +154,8 @@ class DeviceCodeFlow implements OpenIdFlow {
           client_id: config.clientId,
           client_secret: config.useDeviceCodeClientSecret ? config.clientSecret : undefined,
           scope: config.scope || 'openid',
+          audience: config.audience,
+          resource: config.resource,
         }),
       },
       { showProgressBar: false }

--- a/src/plugins/oauth2/flow/implicitFlow.ts
+++ b/src/plugins/oauth2/flow/implicitFlow.ts
@@ -39,6 +39,7 @@ class ImplicitFlow implements OpenIdFlow {
             state,
             response_mode: config.responseMode,
             audience: config.audience,
+            resource: config.resource,
             redirect_uri: config.redirectUri.toString(),
           })}`;
 

--- a/src/plugins/oauth2/flow/passwordFlow.ts
+++ b/src/plugins/oauth2/flow/passwordFlow.ts
@@ -44,6 +44,8 @@ class PasswordFlow implements OpenIdFlow {
             tokenEndpoint: config.tokenEndpoint,
             grantType: 'password',
             username: config.username,
+            audience: config.audience,
+            resource: config.resource,
           },
         },
         context

--- a/src/plugins/oauth2/flow/passwordFlow.ts
+++ b/src/plugins/oauth2/flow/passwordFlow.ts
@@ -32,6 +32,8 @@ class PasswordFlow implements OpenIdFlow {
             scope: config.scope,
             username: config.username,
             password: config.password,
+            audience: config.audience,
+            resource: config.resource,
           }),
         },
         {
@@ -44,8 +46,6 @@ class PasswordFlow implements OpenIdFlow {
             tokenEndpoint: config.tokenEndpoint,
             grantType: 'password',
             username: config.username,
-            audience: config.audience,
-            resource: config.resource,
           },
         },
         context

--- a/src/plugins/oauth2/flow/refreshTokenFlow.ts
+++ b/src/plugins/oauth2/flow/refreshTokenFlow.ts
@@ -22,13 +22,19 @@ class RefreshTokenFlow {
       !this.isTokenExpired(openIdInformation.time, openIdInformation.timeSkew, openIdInformation.refreshExpiresIn)
     ) {
       utils.report(context, 'execute OAuth2 refresh_token flow');
+      const { 
+        tokenEndpoint, scope, resource, audience 
+      } = openIdInformation.config;
       return requestOpenIdInformation(
         {
-          url: openIdInformation.config.tokenEndpoint,
+          url: tokenEndpoint,
           method: 'POST',
           body: utils.toQueryParams({
             grant_type: 'refresh_token',
             refresh_token: openIdInformation.refreshToken,
+            scope,
+            audience,
+            resource,
           }),
         },
         {

--- a/src/plugins/oauth2/openIdConfiguration.ts
+++ b/src/plugins/oauth2/openIdConfiguration.ts
@@ -52,6 +52,7 @@ export function getOpenIdConfiguration(
     responseMode: getVariable(variables, variablePrefix, 'responseMode'),
     audience: getVariable(variables, variablePrefix, 'audience'),
     scope: getVariable(variables, variablePrefix, 'scope'),
+    resource: getVariable(variables, variablePrefix, 'resource'),
     username: getVariable(variables, variablePrefix, 'username'),
     password: getVariable(variables, variablePrefix, 'password'),
     subjectIssuer: getVariable(variables, variablePrefix, 'subjectIssuer'),


### PR DESCRIPTION
[RFC 8707 Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html) defines the `resource` parameter in an OAuth2 token request.

> [This RFC defines] request parameters that enable a client to explicitly signal to an authorization server about the identity of the protected resource(s) to which it is requesting access.

Some Token Authorization services require the use of the `resource` parameter *in addition to* or *instead of* the `scope` and `audience` parameters for multi-tenant or multi-service scenarios.

An example of this is the Azure Access Control Service which is used to obtain App-Only access tokens for SharePoint Online. The `resource` parameter controls for which SharePoint online instance the access is granted instead of issuing an access token for all possible SharePoint services.

In httpyac the `resource` parameter should be optional and behave very similar to the `audience` parameter.