### PR TITLE
Oauth2 Configuration loading and equality comparison

### DIFF
--- a/src/plugins/oauth2/oauth2VariableReplacer.ts
+++ b/src/plugins/oauth2/oauth2VariableReplacer.ts
@@ -5,6 +5,7 @@ import * as utils from '../../utils';
 import * as flows from './flow';
 import { getOpenIdConfiguration } from './openIdConfiguration';
 import { HookCancel } from 'hookpoint';
+import { isEqual } from 'lodash';
 
 export async function oauth2VariableReplacer(
   text: unknown,
@@ -78,10 +79,7 @@ function getSessionOpenIdInformation(
   config: models.OpenIdConfiguration
 ): models.OpenIdInformation | false {
   const openIdInformation = userSessionStore.userSessions.find(obj => obj.id === cacheKey);
-  if (
-    utils.isOpenIdInformation(openIdInformation) &&
-    JSON.stringify(openIdInformation.config) === JSON.stringify(config)
-  ) {
+  if (utils.isOpenIdInformation(openIdInformation) && isEqual(openIdInformation.config, config)) {
     return openIdInformation;
   }
   return false;

--- a/src/plugins/oauth2/oauth2VariableReplacer.ts
+++ b/src/plugins/oauth2/oauth2VariableReplacer.ts
@@ -3,9 +3,8 @@ import type * as models from '../../models';
 import { userSessionStore } from '../../store';
 import * as utils from '../../utils';
 import * as flows from './flow';
-import { getOpenIdConfiguration } from './openIdConfiguration';
+import { getOpenIdConfiguration, isOpenIdConfigurationEqual } from './openIdConfiguration';
 import { HookCancel } from 'hookpoint';
-import { isEqual } from 'lodash';
 
 export async function oauth2VariableReplacer(
   text: unknown,
@@ -79,7 +78,7 @@ function getSessionOpenIdInformation(
   config: models.OpenIdConfiguration
 ): models.OpenIdInformation | false {
   const openIdInformation = userSessionStore.userSessions.find(obj => obj.id === cacheKey);
-  if (utils.isOpenIdInformation(openIdInformation) && isEqual(openIdInformation.config, config)) {
+  if (utils.isOpenIdInformation(openIdInformation) && isOpenIdConfigurationEqual(openIdInformation.config, config)) {
     return openIdInformation;
   }
   return false;

--- a/src/plugins/oauth2/openIdConfiguration.ts
+++ b/src/plugins/oauth2/openIdConfiguration.ts
@@ -1,6 +1,7 @@
 import { log, userInteractionProvider } from '../../io';
 import type * as models from '../../models';
 import * as utils from '../../utils';
+import { isEqualWith } from 'lodash';
 import get from 'lodash/get';
 import { URL } from 'url';
 
@@ -65,6 +66,20 @@ export function getOpenIdConfiguration(
     usePkce: ['true', '1', true].indexOf(getVariable(variables, variablePrefix, 'usePkce')) >= 0,
   };
   return config;
+}
+
+export function isOpenIdConfigurationEqual(
+  config1: models.OpenIdConfiguration,
+  config2: models.OpenIdConfiguration
+): boolean {
+  return isEqualWith(config1, config2, (prop1, prop2, key) => {
+    const urlKeys: (keyof models.OpenIdConfiguration)[] = ['redirectUri'];
+    const propname = key as keyof models.OpenIdConfiguration;
+    if (key && urlKeys.includes(propname)) {
+      return `${prop1}` === `${prop2}`;
+    }
+    return undefined;
+  });
 }
 
 export function assertConfiguration(config: models.OpenIdConfiguration, keys: string[]): boolean {

--- a/src/plugins/oauth2/openIdConfiguration.ts
+++ b/src/plugins/oauth2/openIdConfiguration.ts
@@ -16,8 +16,18 @@ function getVariableRaw(variables: models.Variables, name: string, variablePrefi
   return varValue;
 }
 
+function ensureString(expandedValue: unknown): string {
+  if (typeof expandedValue === 'undefined' || expandedValue === null) {
+    return '';
+  }
+  if (utils.isString(expandedValue)) {
+    return expandedValue;
+  }
+  return `${expandedValue}`;
+}
+
 function getVariableUnknown(variables: models.Variables, variablePrefix: string | undefined, name: string): unknown {
-  const getter = getVariableRaw.bind(undefined, variables, name);
+  const getter = (prefix: string) => getVariableRaw(variables, name, prefix);
   let value: unknown;
   if (variablePrefix) {
     value = getter(variablePrefix);
@@ -31,13 +41,7 @@ function getVariableUnknown(variables: models.Variables, variablePrefix: string 
 
 function getString(variables: models.Variables, variablePrefix: string | undefined, name: string): string {
   const expandedValue = getVariableUnknown(variables, variablePrefix, name);
-  if (typeof expandedValue === 'undefined' || expandedValue === null) {
-    return '';
-  }
-  if (utils.isString(expandedValue)) {
-    return expandedValue;
-  }
-  return `${expandedValue}`;
+  return ensureString(expandedValue);
 }
 
 function getBooleanLike(
@@ -49,8 +53,7 @@ function getBooleanLike(
   const expandedValue = getVariableUnknown(variables, variablePrefix, name);
   if (typeof expandedValue === 'boolean') return expandedValue;
   if (typeof expandedValue === 'number') return !!expandedValue;
-  if (typeof expandedValue === 'undefined' || expandedValue === null) return defaultValue;
-  const stringValue = utils.isString(expandedValue) ? expandedValue : `${expandedValue}`;
+  const stringValue = ensureString(expandedValue);
   const trimmedValue = stringValue.trim();
   if (!trimmedValue) return defaultValue;
   if (/^true$/iu.test(trimmedValue)) return true;


### PR DESCRIPTION
The previous code to read OAuth2 configuration from variables was capable of this from strings and non-falsy values only. A variable that was somehow (e.g. in JSON configuration) set to a value of `0` or `false` could not be set to a `true`-defaulting configuration property (e.g. `useAuthorizationHeader`).

The PR splits up the functionality to read variables to config by creating `getString()` and `getBooleanLike()`. The getter now only falls back additional sources (`oauth2_varname` -> `oauth2.varname` and `prefix_value` -> `oauth2_value`) when the value read is `undefined` or `null`, thus allowing for an actual value of `0` or `false`.

Additionally, if a OAuth2 session was created by script, the previous equality comparison would in some cases erroneously compare two OAuth2 configurations as not equal, even though all property values were equal. This happens when properties are added to a config object in a different order which would make the resulting JSON be different.

The PR makes use of the `isEqualWith` function from `lodash` using a custom comparer to handle URL-properties by stringifying these.