### PR TITLE
VS Code launch debugger in integrated terminal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,15 +2,19 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "pwa-node",
+      "type": "node",
       "request": "launch",
       "name": "launch",
       "skipFiles": [
         "<node_internals>/**"
       ],
       "cwd": "${fileDirname}",
+      "console": "integratedTerminal",
       "program": "${workspaceFolder}/bin/httpyac.js",
-      "args": ["${fileBasename}", "--all"],
+      "args": [
+        "send",
+        "${file}"
+      ],
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],


### PR DESCRIPTION
The default console for VS Code is the internal console. The problem with the internal console is that it cannot be used with user interaction. This PR suggest to use an integrated terminal window instead, allowing to debug http files that use script code using the `userInteractionProvider`.

Httpyac is also not a node.js web application, but a console app. Changing the debugger type to reflect this.