### PR TITLE
@import and @ref track dependencies

### DIFF
--- a/src/plugins/core/metaData/importMetaDataHandler.ts
+++ b/src/plugins/core/metaData/importMetaDataHandler.ts
@@ -2,7 +2,7 @@ import * as io from '../../../io';
 import * as models from '../../../models';
 import * as utils from '../../../utils';
 import { isGlobalHttpRegion } from '../../../utils';
-import { registerRegionDependent, resetDependentRegions } from './refMetaDataHandler';
+import { registerRegionDependent } from './refMetaDataHandler';
 
 export function importMetaDataHandler(type: string, value: string | undefined, context: models.ParserContext) {
   if (type === 'import' && value) {
@@ -74,7 +74,6 @@ class ImportMetaAction {
       if (globResult) {
         for (const globRegion of httpFile.httpRegions.filter(isGlobalHttpRegion)) {
           registerRegionDependent(context, httpFile, globRegion, context.httpFile, context.httpRegion);
-          resetDependentRegions(context, httpFile, globRegion);
         }
         context.options.globalScriptsExecuted.push(httpFile);
       }

--- a/src/plugins/core/metaData/importMetaDataHandler.ts
+++ b/src/plugins/core/metaData/importMetaDataHandler.ts
@@ -1,8 +1,6 @@
 import * as io from '../../../io';
 import * as models from '../../../models';
 import * as utils from '../../../utils';
-import { isGlobalHttpRegion } from '../../../utils';
-import { registerRegionDependent } from './refMetaDataHandler';
 
 export function importMetaDataHandler(type: string, value: string | undefined, context: models.ParserContext) {
   if (type === 'import' && value) {
@@ -12,20 +10,10 @@ export function importMetaDataHandler(type: string, value: string | undefined, c
   return false;
 }
 
-export interface ImportRegionDependentsEntry {
-  refFile: models.HttpFile;
-  refRegion: models.HttpRegion;
-  dependents: Array<{
-    depFile: models.HttpFile;
-    depRegion: models.HttpRegion;
-  }>;
-}
-
 export interface ImportProcessorContext extends models.ProcessorContext {
   options: {
     httpFiles?: Array<{ base: models.HttpFile; ref: models.HttpFile }>;
     globalScriptsExecuted?: Array<models.HttpFile>;
-    refDependencies?: Array<ImportRegionDependentsEntry>;
   };
 }
 
@@ -72,8 +60,8 @@ class ImportMetaAction {
       };
       const globResult = await utils.executeGlobalScripts(cloneContext);
       if (globResult) {
-        for (const globRegion of httpFile.httpRegions.filter(isGlobalHttpRegion)) {
-          registerRegionDependent(context, httpFile, globRegion, context.httpFile, context.httpRegion);
+        for (const globRegion of httpFile.httpRegions.filter(utils.isGlobalHttpRegion)) {
+          utils.registerRegionDependent(context, httpFile, globRegion, context.httpFile, context.httpRegion);
         }
         context.options.globalScriptsExecuted.push(httpFile);
       }

--- a/src/plugins/core/metaData/importMetaDataHandler.ts
+++ b/src/plugins/core/metaData/importMetaDataHandler.ts
@@ -12,7 +12,7 @@ export function importMetaDataHandler(type: string, value: string | undefined, c
   return false;
 }
 
-interface ImportRegionDependentsEntry {
+export interface ImportRegionDependentsEntry {
   refFile: models.HttpFile;
   refRegion: models.HttpRegion;
   dependents: Array<{

--- a/src/plugins/core/metaData/refMetaDataHandler.ts
+++ b/src/plugins/core/metaData/refMetaDataHandler.ts
@@ -50,7 +50,6 @@ class RefMetaAction {
         if (result) {
           const env = utils.toEnvironmentKey(context.httpFile.activeEnvironment);
           Object.assign(context.variables, refContext.httpRegion.variablesPerEnv[env]);
-          resetDependentRegions(refContext, reference.httpFile, reference.httpRegion);
         }
         return result;
       }

--- a/src/plugins/core/metaData/refMetaDataHandler.ts
+++ b/src/plugins/core/metaData/refMetaDataHandler.ts
@@ -1,7 +1,6 @@
 import { log } from '../../../io';
 import * as models from '../../../models';
 import * as utils from '../../../utils';
-import { toEnvironmentKey } from '../../../utils';
 import { ImportProcessorContext } from './importMetaDataHandler';
 
 export function refMetaDataHandler(type: string, name: string | undefined, context: models.ParserContext): boolean {
@@ -36,7 +35,13 @@ class RefMetaAction {
     }
 
     if (reference) {
-      registerRegionDependent(context, reference.httpFile, reference.httpRegion, context.httpFile, context.httpRegion);
+      utils.registerRegionDependent(
+        context,
+        reference.httpFile,
+        reference.httpRegion,
+        context.httpFile,
+        context.httpRegion
+      );
       const envKey = utils.toEnvironmentKey(context.httpFile.activeEnvironment);
       log.trace('import variables', reference.httpRegion.variablesPerEnv[envKey]);
       Object.assign(context.variables, reference.httpRegion.variablesPerEnv[envKey]);
@@ -82,54 +87,4 @@ class RefMetaAction {
     }
     return undefined;
   }
-}
-
-export function registerRegionDependent(
-  context: ImportProcessorContext,
-  refFile: models.HttpFile,
-  refRegion: models.HttpRegion,
-  dependentFile: models.HttpFile,
-  dependentRegion: models.HttpRegion
-): void {
-  context.options.refDependencies ||= [];
-  let refDepEntry = context.options.refDependencies.find(e => e.refFile === refFile && e.refRegion === refRegion);
-  if (!refDepEntry) {
-    refDepEntry = { refFile, refRegion, dependents: [] };
-    context.options.refDependencies.push(refDepEntry);
-  }
-  const depEntry = refDepEntry.dependents.find(d => d.depFile === dependentFile && d.depRegion === dependentRegion);
-  if (!depEntry) {
-    refDepEntry.dependents.push({
-      depFile: dependentFile,
-      depRegion: dependentRegion,
-    });
-  }
-}
-
-function resetDependentRegionsWithVisitor(
-  context: ImportProcessorContext,
-  refFile: models.HttpFile,
-  refRegion: models.HttpRegion,
-  visitedDependents: Array<{ depFile: models.HttpFile; depRegion: models.HttpRegion }>
-): void {
-  const refDepEntry = context.options.refDependencies?.find(e => e.refFile === refFile && e.refRegion === refRegion);
-  if (!refDepEntry) return;
-  const unvisitedDependents = refDepEntry.dependents.filter(
-    d => !visitedDependents.find(v => v.depFile === d.depFile && v.depRegion === d.depRegion)
-  );
-  for (const { depFile, depRegion } of unvisitedDependents) {
-    delete depRegion.response;
-    delete depRegion.variablesPerEnv[toEnvironmentKey(depFile.activeEnvironment)];
-
-    visitedDependents.push({ depFile, depRegion });
-    resetDependentRegionsWithVisitor(context, depFile, depRegion, visitedDependents);
-  }
-}
-
-export function resetDependentRegions(
-  context: ImportProcessorContext,
-  refFile: models.HttpFile,
-  refRegion: models.HttpRegion
-): void {
-  resetDependentRegionsWithVisitor(context, refFile, refRegion, []);
 }

--- a/src/utils/httpRegionUtils.ts
+++ b/src/utils/httpRegionUtils.ts
@@ -1,4 +1,5 @@
 import * as models from '../models';
+import { resetDependentRegions } from '../plugins/core/metaData/refMetaDataHandler';
 import { toEnvironmentKey } from './environmentUtils';
 import { report } from './logUtils';
 import { cloneResponse } from './requestUtils';
@@ -74,6 +75,7 @@ export async function processHttpRegionActions(
     const newVariables = context.variables;
     context.variables = variables;
     autoShareNewVariables(newVariables, context);
+    resetDependentRegions(context, context.httpFile, context.httpRegion);
   }
 }
 function initRegionScopedVariables(context: models.ProcessorContext) {


### PR DESCRIPTION
This PR introduces dependency tracking for `@ref` and `@import` directives.

When an `@import` directive is processed:
* Add the current HttpRegion as a dependent to each of the imported file's global script regions.

When a `@ref` directive is processed:
* Add the current HttpRegion as a dependent to the referenced HttpRegion.

When `processHttpRegionActions` is called:
* Recursively go though all dependents that were previously added and reset them.  
   Resetting means deleting the `response` property and all variables stored from previous execution (if any).

The dependents for each region is tracked in an array property named `refDependencies` on `ProcessorContext.options`. Each item in the array contains a `dependents` array that refers to the dependent regions that need to be reset, when the region referred to by the entry is re-processed.

Resetting dependents internally keeps track of which region already have been reset when recursively walking the dependencies. That way circular dependencies are ignored in order to avoid stack overflows.