### PR TITLE
Change CLI result message for general purpose usages

### DIFF
--- a/src/cli/send/send.ts
+++ b/src/cli/send/send.ts
@@ -80,7 +80,7 @@ async function execute(fileNames: Array<string>, options: SendOptions): Promise<
         } else if (context.scriptConsole) {
           context.scriptConsole.info('');
           context.scriptConsole.info(
-            chalk`{bold ${cliJsonOutput.summary.totalRequests}} requests tested ({green ${cliJsonOutput.summary.successRequests} succeeded}, {red ${cliJsonOutput.summary.failedRequests} failed})`
+            chalk`{bold ${cliJsonOutput.summary.totalRequests}} requests processed ({green ${cliJsonOutput.summary.successRequests} succeeded}, {red ${cliJsonOutput.summary.failedRequests} failed})`
           );
         }
       }


### PR DESCRIPTION
Currently the CLI ends with printing the message `<number> requests tested (<number> succeeded, <number> failed).`.

I agree that httpyac often will be used when testing APIs, but the description on the [httpyac homepage](https://httpyac.github.io/) indicates that httpYac is a
general-purpose utility.

I propose that we change the word `tested` to `processed` to reflect the general-purpose nature of the tool. In cases when httpyac is used as a testing tool the 
new message `processed` is still correct.
