### PR TITLE
Improve httpRegion dependency tracking

### DIFF
--- a/src/models/httpRegion.ts
+++ b/src/models/httpRegion.ts
@@ -1,3 +1,4 @@
+import { HttpFile } from './httpFile';
 import { ExecuteHook, OnRequestHook, OnStreaming, OnResponseHook, ResponseLoggingHook } from './httpFileHooks';
 import { Request } from './httpRequest';
 import { HttpResponse } from './httpResponse';
@@ -16,6 +17,7 @@ export interface ProcessedHttpRegion {
 
 export interface HttpRegion extends ProcessedHttpRegion {
   variablesPerEnv: Record<string, Variables>;
+  dependentsPerEnv: Record<string, Array<{ httpRegion: HttpRegion; httpFile: HttpFile }>>;
   hooks: {
     execute: ExecuteHook;
     onRequest: OnRequestHook;

--- a/src/store/httpFileStore.ts
+++ b/src/store/httpFileStore.ts
@@ -339,6 +339,7 @@ function initHttpRegion(start: number): models.HttpRegion {
       responseLogging: new models.ResponseLoggingHook(),
     },
     variablesPerEnv: {},
+    dependentsPerEnv: {},
   };
 }
 

--- a/src/utils/httpRegionUtils.ts
+++ b/src/utils/httpRegionUtils.ts
@@ -110,10 +110,14 @@ export function registerRegionDependent(
   dependentFile: models.HttpFile,
   dependentRegion: models.HttpRegion
 ): void {
-  const refDepEntry = refRegion.dependentsPerEnv[toEnvironmentKey(refFile.activeEnvironment)];
-  const depEntry = refDepEntry.find(d => d.httpFile === dependentFile && d.httpRegion === dependentRegion);
+  const envKey = toEnvironmentKey(refFile.activeEnvironment);
+  let refDependents = refRegion.dependentsPerEnv[envKey];
+  if (typeof refDependents === 'undefined') {
+    refDependents = refRegion.dependentsPerEnv[envKey] = [];
+  }
+  const depEntry = refDependents.find(d => d.httpFile === dependentFile && d.httpRegion === dependentRegion);
   if (!depEntry) {
-    refDepEntry.push({
+    refDependents.push({
       httpFile: dependentFile,
       httpRegion: dependentRegion,
     });
@@ -125,8 +129,12 @@ function resetDependentRegionsWithVisitor(
   refRegion: models.HttpRegion,
   visitedDependents: Array<{ httpFile: models.HttpFile; httpRegion: models.HttpRegion }>
 ): void {
-  const refDepEntry = refRegion.dependentsPerEnv[toEnvironmentKey(refFile.activeEnvironment)];
-  const unvisitedDependents = refDepEntry.filter(
+  const envKey = toEnvironmentKey(refFile.activeEnvironment);
+  let refDependents = refRegion.dependentsPerEnv[envKey];
+  if (typeof refDependents === 'undefined') {
+    refDependents = refRegion.dependentsPerEnv[envKey] = [];
+  }
+  const unvisitedDependents = refDependents.filter(
     d => !visitedDependents.find(v => v.httpFile === d.httpFile && v.httpRegion === d.httpRegion)
   );
   for (const { httpFile, httpRegion } of unvisitedDependents) {

--- a/src/utils/httpRegionUtils.ts
+++ b/src/utils/httpRegionUtils.ts
@@ -103,70 +103,47 @@ export async function executeGlobalScripts(context: {
   return true;
 }
 
-interface ImportRegionDependentsEntry {
-  refFile: models.HttpFile;
-  refRegion: models.HttpRegion;
-  dependents: Array<{
-    depFile: models.HttpFile;
-    depRegion: models.HttpRegion;
-  }>;
-}
-
-interface HttpRegionDependenciesContext extends models.ProcessorContext {
-  options: {
-    refDependencies?: Array<ImportRegionDependentsEntry>;
-  };
-}
-
 export function registerRegionDependent(
-  context: models.ProcessorContext,
+  _context: object,
   refFile: models.HttpFile,
   refRegion: models.HttpRegion,
   dependentFile: models.HttpFile,
   dependentRegion: models.HttpRegion
 ): void {
-  const depContext = context as HttpRegionDependenciesContext;
-  depContext.options.refDependencies ||= [];
-  let refDepEntry = depContext.options.refDependencies.find(e => e.refFile === refFile && e.refRegion === refRegion);
-  if (!refDepEntry) {
-    refDepEntry = { refFile, refRegion, dependents: [] };
-    depContext.options.refDependencies.push(refDepEntry);
-  }
-  const depEntry = refDepEntry.dependents.find(d => d.depFile === dependentFile && d.depRegion === dependentRegion);
+  const refDepEntry = refRegion.dependentsPerEnv[toEnvironmentKey(refFile.activeEnvironment)];
+  const depEntry = refDepEntry.find(d => d.httpFile === dependentFile && d.httpRegion === dependentRegion);
   if (!depEntry) {
-    refDepEntry.dependents.push({
-      depFile: dependentFile,
-      depRegion: dependentRegion,
+    refDepEntry.push({
+      httpFile: dependentFile,
+      httpRegion: dependentRegion,
     });
   }
 }
 
 function resetDependentRegionsWithVisitor(
-  context: HttpRegionDependenciesContext,
   refFile: models.HttpFile,
   refRegion: models.HttpRegion,
-  visitedDependents: Array<{ depFile: models.HttpFile; depRegion: models.HttpRegion }>
+  visitedDependents: Array<{ httpFile: models.HttpFile; httpRegion: models.HttpRegion }>
 ): void {
-  const refDepEntry = context.options.refDependencies?.find(e => e.refFile === refFile && e.refRegion === refRegion);
-  if (!refDepEntry) return;
-  const unvisitedDependents = refDepEntry.dependents.filter(
-    d => !visitedDependents.find(v => v.depFile === d.depFile && v.depRegion === d.depRegion)
+  const refDepEntry = refRegion.dependentsPerEnv[toEnvironmentKey(refFile.activeEnvironment)];
+  const unvisitedDependents = refDepEntry.filter(
+    d => !visitedDependents.find(v => v.httpFile === d.httpFile && v.httpRegion === d.httpRegion)
   );
-  for (const { depFile, depRegion } of unvisitedDependents) {
-    delete depRegion.response;
-    delete depRegion.variablesPerEnv[toEnvironmentKey(depFile.activeEnvironment)];
+  for (const { httpFile, httpRegion } of unvisitedDependents) {
+    delete httpRegion.response;
+    delete httpRegion.variablesPerEnv[toEnvironmentKey(httpFile.activeEnvironment)];
 
-    visitedDependents.push({ depFile, depRegion });
-    resetDependentRegionsWithVisitor(context, depFile, depRegion, visitedDependents);
+    visitedDependents.push({ httpFile, httpRegion });
+    resetDependentRegionsWithVisitor(httpFile, httpRegion, visitedDependents);
   }
 }
 
 export function resetDependentRegions(
-  context: models.ProcessorContext,
+  _context: object,
   refFile: models.HttpFile,
   refRegion: models.HttpRegion
 ): void {
-  resetDependentRegionsWithVisitor(context, refFile, refRegion, []);
+  resetDependentRegionsWithVisitor(refFile, refRegion, []);
 }
 
 export function isGlobalHttpRegion(httpRegion: models.HttpRegion): boolean {

--- a/src/utils/httpRegionUtils.ts
+++ b/src/utils/httpRegionUtils.ts
@@ -1,3 +1,4 @@
+import * as io from '../io';
 import * as models from '../models';
 import { toEnvironmentKey } from './environmentUtils';
 import { report } from './logUtils';
@@ -138,6 +139,7 @@ function resetDependentRegionsWithVisitor(
     d => !visitedDependents.find(v => v.httpFile === d.httpFile && v.httpRegion === d.httpRegion)
   );
   for (const { httpFile, httpRegion } of unvisitedDependents) {
+    io.log.trace(`resetting '${httpFile.fileName}:${getDisplayName(httpRegion)}': dependent of '${refFile.fileName}:${getDisplayName(refRegion)}'`);
     delete httpRegion.response;
     delete httpRegion.variablesPerEnv[toEnvironmentKey(httpFile.activeEnvironment)];
 


### PR DESCRIPTION
A non-global httpRegion should implicitly be dependent on the global regions of the file.

Since global regions are always executed when `@import`-ing or directly executing a region in a file, it is not helpful to invalidate their dependents when global regions are executed. Since a global region cannot be `@ref`-ed in itself that is okay.

Having the dependency tracking on the context is not ideal: the context is recreated every time the httpyac-CLI or VS Code execute a region or file. Instead dependency tracking should really be a feature of the region itself.

This makes the `context` argument for the `registerRegionDependent` and `resetDependentRegions` functions obsolete. I kept the argument (and retyped it to `any`) to keep backwards compatibility.