### PR TITLE
Set referenced HttpRegion variables properly in context

### DIFF
--- a/src/plugins/core/metaData/refMetaDataHandler.ts
+++ b/src/plugins/core/metaData/refMetaDataHandler.ts
@@ -44,7 +44,7 @@ class RefMetaAction {
       );
       const envKey = utils.toEnvironmentKey(context.httpFile.activeEnvironment);
       log.trace('import variables', reference.httpRegion.variablesPerEnv[envKey]);
-      Object.assign(context.variables, reference.httpRegion.variablesPerEnv[envKey]);
+      utils.setVariableInContext(reference.httpRegion.variablesPerEnv[envKey], context);
       if (this.data.force || !context.variables[this.data.name]) {
         const refContext = {
           ...context,
@@ -53,8 +53,7 @@ class RefMetaAction {
         };
         const result = await utils.processHttpRegionActions(refContext);
         if (result) {
-          const env = utils.toEnvironmentKey(context.httpFile.activeEnvironment);
-          Object.assign(context.variables, refContext.httpRegion.variablesPerEnv[env]);
+          utils.setVariableInContext(refContext.httpRegion.variablesPerEnv[envKey], context);
         }
         return result;
       }


### PR DESCRIPTION
When using the `ref` directive in an Http Region, we currently simply assign the `variablesPerEnv[envKey]` of the referenced region to the variables of the currently executing context.

It turns out that this is not sufficient for tracking transitive `ref`s (i.e. `ref` of a `ref`).

Therefore, I propose that we change the implementation in `refMetaDataHandler` to use the `utils` function `setVariableInContext` instead of a simple `Object.assign`. This will properly store both direct and transitive referenced variables in `variablesPerEnv[envKey]`.