### PR TITLE
feat: add user with space in http auth digest

### DIFF
--- a/src/__tests__/httpYacApi.test.ts
+++ b/src/__tests__/httpYacApi.test.ts
@@ -630,14 +630,21 @@ Authorization: Basic john doe
       await exec(`
 GET  http://localhost:8080/json
 Authorization: Digest john doe
+
+###
+GET  http://localhost:8080/json
+Authorization: Digest john:doe
       `);
 
       const authMissingRequests = await missingAuthEndpoints.getSeenRequests();
-      expect(authMissingRequests.length).toBe(1);
+      expect(authMissingRequests.length).toBe(2);
       const requests = await mockedEndpoints.getSeenRequests();
-      expect(requests[0].headers.authorization).toBe(
-        'Digest username="john", realm="json@localhost", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/json", response="4d157d692f3e05a1cbe192ddbc427782", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
-      );
+      expect(requests.length).toBe(2);
+      for (const request of requests) {
+        expect(request.headers.authorization).toBe(
+          'Digest username="john", realm="json@localhost", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", uri="/json", response="4d157d692f3e05a1cbe192ddbc427782", opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+        );
+      }
     });
 
     it('set string variable', async () => {

--- a/src/plugins/http/digestAuthVariableReplacer.ts
+++ b/src/plugins/http/digestAuthVariableReplacer.ts
@@ -5,13 +5,15 @@ import type { CancelableRequest, OptionsOfUnknownResponseBody, Response } from '
 import { URL } from 'url';
 import { v4 as uuid } from 'uuid';
 
+const DigestAuth = /^\s*(digest)\s+(?<user>[^\s]*)\s+(?<password>([^\s]+.*))$/iu;
+const DigestAuthColon = /^\s*(digest)\s+(?<user>.*):(?<password>.*)$/iu;
 export async function digestAuthVariableReplacer(
   text: unknown,
   type: string,
   { request }: ProcessorContext
 ): Promise<unknown> {
   if (type.toLowerCase() === 'authorization' && isString(text) && isHttpRequest(request)) {
-    const match = /^\s*(digest)\s+(?<user>[^\s]*)\s+(?<password>([^\s]+.*))$/iu.exec(text);
+    const match = DigestAuthColon.exec(text) || DigestAuth.exec(text);
 
     if (match && match.groups && match.groups.user && match.groups.password) {
       if (!request.options.hooks) {


### PR DESCRIPTION
Simple fix to use username that includes space.
This just follows an idea from `Basic Authentication HTTP` plugin - using ':' in such cases.
See https://httpyac.github.io/guide/variables.html#basic-authentication

Had problems to test it on [httpbin](https://httpbin.org) API, but on real system it worked for me.

If you like this idea highly probably docs need to be updated as well ;)