### PR TITLE
Publish `initFileProvider` function

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,1 +1,2 @@
 export * from './cli';
+export * from './initCliProvider';

--- a/src/cli/initCliProvider.ts
+++ b/src/cli/initCliProvider.ts
@@ -18,7 +18,7 @@ function initFixTestSymbols() {
   }
 }
 
-function initFileProvider(): void {
+export function initFileProvider(): void {
   fileProvider.EOL = EOL;
   fileProvider.isAbsolute = async (path: models.PathLike) => isAbsolute(fileProvider.toString(path));
   fileProvider.dirname = (path: string) => dirname(fileProvider.toString(path));


### PR DESCRIPTION
I am using httpyac without CLI interface, and directly in JS code:

```js
async function run(content) {
    initFileProvider(); // not accessible, I had to copy this from httpyac into my file
    const httpFileStore = new store.HttpFileStore();
    const httpFile = await httpFileStore.getOrCreate('file.http', async () => (content), 0, {});
    const httpRegion = httpFile.httpRegions[0];
    const context = {httpFile, httpRegion, processedHttpRegions: []};
    const result = await send(context);
    return context.processedHttpRegions[0];
}

run(`GET https://dev.our-website.com/path/1`)
```

Being able to conveniently initialize it with defaults is useful.