### PR TITLE
Allow async/await syntax in code snippets

### DIFF
--- a/src/plugins/javascript/moduleUtils.ts
+++ b/src/plugins/javascript/moduleUtils.ts
@@ -114,12 +114,13 @@ export async function runScript(
   );
 
   const contextKeys = Object.keys(context);
-  const compiledWrapper = vm.runInContext(Module.wrap(`${io.fileProvider.EOL}${source}`), context, {
+  const sourceAsync = `return (async()=>{${io.fileProvider.EOL}${source}})()`;
+  const compiledWrapper = vm.runInContext(Module.wrap(sourceAsync), context, {
     filename,
     lineOffset: options.lineOffset,
     displayErrors: true,
   });
-  compiledWrapper.apply(context, [mod.exports, extendedRequire, mod, filename, path.dirname(filename)]);
+  await compiledWrapper.apply(context, [mod.exports, extendedRequire, mod, filename, path.dirname(filename)]);
 
   deleteVariables(contextKeys, context, options.deleteVariable);
 

--- a/src/test/variables/variables.spec.ts
+++ b/src/test/variables/variables.spec.ts
@@ -145,4 +145,19 @@ GET http://localhost:6005/test?test={{JSON.stringify(testObj)}}
     const requests = await mockedEndpoints.getSeenRequests();
     expect(requests[0].url).toBe('http://localhost:6005/test?test={%22bar%22:%22works%22}');
   });
+
+  it('support await syntax in custom scripts', async () => {
+    initFileProvider();
+    const mockedEndpoints = await localServer.forGet('/test').thenJson(200, { slideshow: { author: 'httpyac' } });
+    await sendHttp(`
+{{
+const asyncFn = async () => ({ bar: 'works'});
+exports.testObj = await asyncFn();
+}}
+GET http://localhost:6005/test?test={{JSON.stringify(testObj)}}
+    `);
+
+    const requests = await mockedEndpoints.getSeenRequests();
+    expect(requests[0].url).toBe('http://localhost:6005/test?test={%22bar%22:%22works%22}');
+  });
 });


### PR DESCRIPTION
pretty useful to be able to run asynchronous functions and collect data to pass to a request