### PR TITLE
fix: unable to use variable as graphql input

### DIFF
--- a/src/plugins/graphql/gqlAction.ts
+++ b/src/plugins/graphql/gqlAction.ts
@@ -1,5 +1,5 @@
 import { log, userInteractionProvider } from '../../io';
-import { ProcessorContext } from '../../models';
+import { ProcessorContext, Request } from '../../models';
 import * as utils from '../../utils';
 
 export type GqlLoadData = string | ((context: ProcessorContext) => Promise<string | undefined>);
@@ -22,8 +22,8 @@ export class GqlAction {
 
   constructor(private readonly gqlData: GqlData) {}
 
-  async process(context: ProcessorContext): Promise<boolean> {
-    if (context.request && this.gqlData?.query) {
+  async process(request: Request, context: ProcessorContext): Promise<void> {
+    if (request && this.gqlData?.query) {
       utils.report(context, 'build GraphQL query');
       let query: string | undefined;
       if (utils.isString(this.gqlData.query)) {
@@ -66,12 +66,11 @@ export class GqlAction {
         if (this.gqlData.operationName) {
           gqlRequestBody.operationName = this.gqlData.operationName;
         }
-        if (utils.isString(context.request.body)) {
-          gqlRequestBody.variables = JSON.parse(context.request.body);
+        if (utils.isString(request.body)) {
+          gqlRequestBody.variables = JSON.parse(request.body);
         }
-        context.request.body = utils.stringifySafe(gqlRequestBody);
+        request.body = utils.stringifySafe(gqlRequestBody);
       }
     }
-    return true;
   }
 }

--- a/src/plugins/graphql/gqlHttpRegionParser.ts
+++ b/src/plugins/graphql/gqlHttpRegionParser.ts
@@ -29,7 +29,7 @@ export async function parseGraphql(
           context.httpRegion.metaData.name = gqlContent.name;
         }
       }
-      context.httpRegion.hooks.execute.addObjHook(obj => obj.process, new GqlAction(gqlData));
+      context.httpRegion.hooks.onRequest.addObjHook(obj => obj.process, new GqlAction(gqlData));
     } else if (gqlContent.name) {
       gqlData.fragments[gqlContent.name] = gqlContent.gql;
     }

--- a/src/store/httpRegion.ts
+++ b/src/store/httpRegion.ts
@@ -38,7 +38,7 @@ export class HttpRegion implements models.HttpRegion {
     const httpRegion = new HttpRegion(this.httpFile);
     httpRegion.request = this.request;
     Object.assign(httpRegion.symbol, this.symbol);
-    Object.assign(httpRegion.hooks, this.symbol);
+    Object.assign(httpRegion.hooks, this.hooks);
     Object.assign(httpRegion.variablesPerEnv, this.variablesPerEnv);
     Object.assign(httpRegion.metaData, this.metaData);
     return httpRegion;

--- a/src/test/request/graphql.spec.ts
+++ b/src/test/request/graphql.spec.ts
@@ -86,6 +86,49 @@ query launchesQuery($limit: Int!){
     );
   });
 
+  it('query + operation + loop', async () => {
+    initFileProvider();
+    const mockedEndpoints = await localServer.forPost('/graphql').thenReply(200);
+
+    await sendHttp(`
+{{
+  exports.variables = {
+    "limit": 10
+  };
+}}
+
+# @loop for 1
+POST  http://localhost:7002/graphql
+
+query launchesQuery($limit: Int!){
+  launchesPast(limit: $limit) {
+    mission_name
+    launch_date_local
+    launch_site {
+      site_name_long
+    }
+    rocket {
+      rocket_name
+      rocket_type
+    }
+    ships {
+      name
+      home_port
+      image
+    }
+  }
+}
+
+{{ variables }}
+    `);
+
+    const requests = await mockedEndpoints.getSeenRequests();
+    expect(requests[0].url).toBe('http://localhost:7002/graphql');
+    expect(await requests[0].body.getText()).toBe(
+      '{"query":"query launchesQuery($limit: Int!){\\n  launchesPast(limit: $limit) {\\n    mission_name\\n    launch_date_local\\n    launch_site {\\n      site_name_long\\n    }\\n    rocket {\\n      rocket_name\\n      rocket_type\\n    }\\n    ships {\\n      name\\n      home_port\\n      image\\n    }\\n  }\\n}","operationName":"launchesQuery","variables":{"limit":10}}'
+    );
+  });
+
   it('query + operation + partial variable replacement', async () => {
     initFileProvider();
     const mockedEndpoints = await localServer.forPost('/graphql').thenReply(200);


### PR DESCRIPTION
This PR add the ability to use variable as GraphQL query variables, e.g.
```
{{
  exports.variables = {
    "limit": 10
  };
}}

POST  http://localhost:7002/graphql

query launchesQuery($limit: Int!){
  launchesPast(limit: $limit) {
    mission_name
  }
}

{{ variables }}
```
OR
```
{{
  exports.variables = {
    "foo": 10,
    "bar": 20
  };
}}

POST  http://localhost:7002/graphql

query launchesQuery($limit: ComplexInput!){
  launchesPast(limit: $limit) {
    mission_name
  }
}

{
  "limit": {{ variables }}
}
```

Above requests raise exception in current version, because `JSON.parse` was hooked on `execute` event, which happens before variable replacement.
