### PR TITLE
Add additional npmignore rules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,12 @@ assets
 buildSrc
 icon.png
 .github
+tsconfig.json
+tsconfig.*.json
+jest.config.js
+.dockerignore
+.eslintrc.yml
+.prettierignore.yaml
+.husky
+Dockerfile
+coverage


### PR DESCRIPTION
When installing httpyac as a depdendency, e.g. when develing httpyac-plugins the downloaded package from npmjs includes additional files that are unnecessary to be bundled in the package.

When using TypeScript aware editors (e.g. VSCode), the tsconfig.json files in the package are picked up when doing `Go to definition` actions. This leads to temporary false-positive error messages in VS Code (since the .ts files are not included in the package and the tsconfig thus does not find any matching files.)

I have added several rules for files that currently are included, but unnecessary. I use [JSDelivr](https://www.jsdelivr.com/package/npm/httpyac?tab=files) for viewing which files are included in the npm distributed package.
