### PR TITLE
Add support for linux/arm64 docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,13 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - run: npm run docker_build
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -40,9 +47,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Extending the docker build task to build images for platforms: linux/amd64, linux/arm64 which enables native Apple Silicon support

FYI: that's just a c&p from https://github.com/marketplace/actions/build-and-push-docker-images I couldn't test it so far