### PR TITLE
fix: `output-failed` didn't work

### DIFF
--- a/src/cli/send/jsonOutput.ts
+++ b/src/cli/send/jsonOutput.ts
@@ -46,8 +46,8 @@ export function toSendJsonOutput(
     requests.push(
       ...httpRegions.map(httpRegion => {
         let output = options.output;
-        if (options['output-failed'] && httpRegion.testResults?.some?.(test => !test.result)) {
-          output = options['output-failed'];
+        if (options.outputFailed && httpRegion.testResults?.some?.(test => !test.result)) {
+          output = options.outputFailed;
         }
         const result: SendOutputRequest = {
           fileName,

--- a/src/cli/send/options.ts
+++ b/src/cli/send/options.ts
@@ -18,9 +18,9 @@ export interface SendOptions {
   insecure?: boolean;
   json?: boolean;
   output?: OutputType;
-  'output-failed'?: OutputType;
+  outputFailed?: OutputType;
   raw?: boolean;
-  'repeat-mode'?: 'sequential' | 'parallel';
+  repeatMode?: 'sequential' | 'parallel';
   repeat?: number;
   parallel?: number;
   timeout?: number;

--- a/src/cli/send/send.ts
+++ b/src/cli/send/send.ts
@@ -275,14 +275,15 @@ function getRequestLogger(
     options.filter === SendFilterOptions.onlyFailed,
     !options.raw
   );
-  if (requestLoggerOptions) {
-    const logger = utils.requestLoggerFactory(
-      console.info,
-      requestLoggerOptions,
-      options.outputFailed
-        ? getRequestLoggerOptions(options.outputFailed, options.filter === SendFilterOptions.onlyFailed, !options.raw)
-        : undefined
-    );
+
+  const requestFailedLoggerOptions = getRequestLoggerOptions(
+    options.outputFailed,
+    options.filter === SendFilterOptions.onlyFailed,
+    !options.raw
+  );
+
+  if (requestLoggerOptions || requestFailedLoggerOptions) {
+    const logger = utils.requestLoggerFactory(console.info, requestLoggerOptions, requestFailedLoggerOptions);
     return async (response, httpRegion) => {
       await logger(response, httpRegion);
       scriptConsole.flush();

--- a/src/cli/send/send.ts
+++ b/src/cli/send/send.ts
@@ -116,8 +116,7 @@ export function convertCliOptionsToContext(cliOptions: SendOptions) {
     repeat: cliOptions.repeat
       ? {
           count: cliOptions.repeat,
-          type:
-            cliOptions['repeat-mode'] === 'sequential' ? models.RepeatOrder.sequential : models.RepeatOrder.parallel,
+          type: cliOptions.repeatMode === 'sequential' ? models.RepeatOrder.sequential : models.RepeatOrder.parallel,
         }
       : undefined,
     scriptConsole,
@@ -280,12 +279,8 @@ function getRequestLogger(
     const logger = utils.requestLoggerFactory(
       console.info,
       requestLoggerOptions,
-      options['output-failed']
-        ? getRequestLoggerOptions(
-            options['output-failed'],
-            options.filter === SendFilterOptions.onlyFailed,
-            !options.raw
-          )
+      options.outputFailed
+        ? getRequestLoggerOptions(options.outputFailed, options.filter === SendFilterOptions.onlyFailed, !options.raw)
         : undefined
     );
     return async (response, httpRegion) => {

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -175,13 +175,17 @@ export interface RequestLoggerFactoryOptions {
 
 export function requestLoggerFactory(
   log: (args: string) => void,
-  options: RequestLoggerFactoryOptions,
+  options?: RequestLoggerFactoryOptions,
   optionsFailed?: RequestLoggerFactoryOptions
 ): models.RequestLogger {
   return async function logResponse(response: models.HttpResponse, httpRegion?: models.HttpRegion): Promise<void> {
     let opt = options;
     if (optionsFailed && httpRegion?.testResults && httpRegion.testResults.some(obj => !obj.result)) {
       opt = optionsFailed;
+    }
+
+    if (!opt) {
+      return;
     }
 
     if (opt.onlyFailed && (!httpRegion?.testResults || httpRegion.testResults.every(obj => obj.result))) {
@@ -227,7 +231,7 @@ export function requestLoggerFactory(
 
       if (isString(response.body) && opt.responseBodyLength !== undefined) {
         let body: string | undefined = response.body;
-        if (options.responseBodyPrettyPrint && response.prettyPrintBody) {
+        if (opt.responseBodyPrettyPrint && response.prettyPrintBody) {
           body = response.prettyPrintBody;
         }
         body = getPartOfBody(body, opt.responseBodyLength);


### PR DESCRIPTION
fix 2 problems
1. Multi-word options, e.g. `output-failed` and `repeat-mode` were not parsed correctly. See [documentation of commander](https://github.com/tj/commander.js#options )
2. `output-failed` option was ignored if `output` option was set to `none`

see https://github.com/AnWeber/httpyac/issues/460