### PR TITLE
Add httpClientProvider and javascriptProvider to HttpHooksApi

### DIFF
--- a/src/models/httpHooksApi.ts
+++ b/src/models/httpHooksApi.ts
@@ -2,7 +2,9 @@ import * as utils from '../utils';
 import { EnvironmentConfig } from './environmentConfig';
 import { FileProvider } from './fileProvider';
 import { HttpFileHooks } from './hooks';
+import { HttpClientProvider } from './httpClientProvider';
 import { HttpFile } from './httpFile';
+import { JavascriptProvider } from './javascriptProvider';
 import { LogHandler } from './logHandler';
 import { PathLike } from './pathLike';
 import { SessionStore } from './sessionStore';
@@ -21,6 +23,8 @@ export interface HttpyacHooksApi {
   readonly fileProvider: FileProvider;
   readonly sessionStore: SessionStore;
   readonly userInteractionProvider: UserInteractionProvider;
+  readonly httpClientProvider: HttpClientProvider;
+  readonly javascriptProvider: JavascriptProvider;
   readonly utils: typeof utils;
   getHookCancel(): typeof HookCancel;
 }

--- a/src/store/httpFileStore.ts
+++ b/src/store/httpFileStore.ts
@@ -1,4 +1,4 @@
-import { fileProvider, log, userInteractionProvider } from '../io';
+import { fileProvider, httpClientProvider, javascriptProvider, log, userInteractionProvider } from '../io';
 import * as models from '../models';
 import { userSessionStore as sessionStore } from '../store';
 import * as utils from '../utils';
@@ -178,6 +178,8 @@ export class HttpFileStore implements models.HttpFileStore {
         fileProvider,
         sessionStore,
         userInteractionProvider,
+        httpClientProvider,
+        javascriptProvider,
         utils,
         getHookCancel: () => HookCancel,
       };


### PR DESCRIPTION
# TL;DR

Adds the `httpClientProvider` and `javascriptProvider` singletons from `io` to the `HttpyacHooksApi` interface.

## `httpClientProvider`

If a plugin needs to do HTTP requests as part of its implementation it would be advantageous if the plugin could perform HTTP requests in the exact same way that Httpyac does. In doing so, the plugin would now no longer need to depend on an http-client, e.g. got, itself.

## `javascriptProvider`

When executing a script block in an HttpRegion the executed code gets access to a set of default modules (e.g. `httpyac` itself, `dayjs`, `vscode`, etc.). However, plugin authors do not get access to these modules. Moreover, some of these modules are in itself extendable (e.g. dayjs), but a plgin would have no direct means to access these.

Currently a plugin would need to call `utils.replaceVariables` and supply a JavaScript expression to obtain these modules.
