### PR TITLE
Assert symbol not resolved fix

### DIFF
--- a/src/plugins/assert/assertHttpRegionParser.ts
+++ b/src/plugins/assert/assertHttpRegionParser.ts
@@ -70,7 +70,7 @@ export async function parseAssertLine(
         symbols: [
           {
             name: `assert ${match.groups.type}`,
-            description: match.groups.value ?? "script",
+            description: `${match.groups.predicate} ${match.groups.expected || ''}`.trim(),
             kind: models.HttpSymbolKind.script,
             startLine: next.value.line,
             startOffset: 0,

--- a/src/plugins/assert/assertHttpRegionParser.ts
+++ b/src/plugins/assert/assertHttpRegionParser.ts
@@ -69,7 +69,7 @@ export async function parseAssertLine(
         nextParserLine: next.value.line,
         symbols: [
           {
-            name: match.groups.key ?? "script",
+            name: `assert ${match.groups.type}`,
             description: match.groups.value ?? "script",
             kind: models.HttpSymbolKind.script,
             startLine: next.value.line,

--- a/src/plugins/assert/assertHttpRegionParser.ts
+++ b/src/plugins/assert/assertHttpRegionParser.ts
@@ -69,8 +69,8 @@ export async function parseAssertLine(
         nextParserLine: next.value.line,
         symbols: [
           {
-            name: match.groups.key,
-            description: match.groups.value,
+            name: match.groups.key ?? "script",
+            description: match.groups.value ?? "script",
             kind: models.HttpSymbolKind.script,
             startLine: next.value.line,
             startOffset: 0,

--- a/src/test/parser/parser.spec.ts
+++ b/src/test/parser/parser.spec.ts
@@ -48,4 +48,24 @@ describe('parser', () => {
       expect(httpRegion.symbol.source?.trim()).toBe(`GET https://httpbin.org/anything\n    ...defaultHeaders`);
     }
   });
+  it('should support asserts', async () => {
+    const httpFile = await parseHttp(`
+    GET https://httpbin.org/anything
+    ?? status == 200
+    `);
+    expect(await httpFile.fileName).toBe('any.http');
+    expect(await httpFile.httpRegions.length).toBe(1);
+
+
+    for (const httpRegion of httpFile.httpRegions) {
+      expect(httpRegion.request).toBeDefined();
+      expect(httpRegion.request?.url).toBe('https://httpbin.org/anything');
+      expect(httpRegion.symbol.children?.length).toBe(2);
+      expect(httpRegion.symbol.children[0].name).toBe('    GET https://httpbin.org/anything');
+      expect(httpRegion.symbol.children[0].description).toBe('HTTP request-line');
+      expect(httpRegion.symbol.children[1].name).toBe('script');
+      expect(httpRegion.symbol.children[1].description).toBe('script');
+
+    }
+  });
 });


### PR DESCRIPTION
vscode plugin outline is broken when assert if used. e.g.
```
GET https://httpbin.org/anything
?? status == 200
```

After investigation, I found that issue might be related how regexp is written. I added test and default values in order to be null safe.
