### PR TITLE
fix: add classname, time and file to testcases

### DIFF
--- a/src/cli/send/junitUtils.spec.ts
+++ b/src/cli/send/junitUtils.spec.ts
@@ -40,8 +40,8 @@ describe('transformToJunit', () => {
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="httpyac" tests="1" errors="0" disabled="0" failues="0" time="1.001">
   <testsuite name="test.http" tests="1" failures="0" skipped="0" package="." time="1.001" file="test.http">
-    <testsuite name="test" tests="1" failures="0" skipped="0" package="test.http" time="1.001">
-      <testcase name="status == 200" assertions="1"/>
+    <testsuite name="test" tests="1" failures="0" skipped="0" file="test.http" package="test.http" time="1.001">
+      <testcase name="status == 200" classname="test" file="test.http" time="1.001" assertions="1"/>
     </testsuite>
   </testsuite>
 </testsuites>
@@ -122,16 +122,16 @@ describe('transformToJunit', () => {
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="httpyac" tests="3" errors="0" disabled="0" failues="0" time="3.005">
   <testsuite name="test.http" tests="2" failures="0" skipped="0" package="." time="2.003" file="test.http">
-    <testsuite name="test" tests="1" failures="0" skipped="0" package="test.http" time="1.001">
-      <testcase name="status == 200" assertions="1"/>
+    <testsuite name="test" tests="1" failures="0" skipped="0" file="test.http" package="test.http" time="1.001">
+      <testcase name="status == 200" classname="test" file="test.http" time="1.001" assertions="1"/>
     </testsuite>
-    <testsuite name="test2" tests="1" failures="0" skipped="0" package="test.http" time="1.002">
-      <testcase name="status == 200" assertions="1"/>
+    <testsuite name="test2" tests="1" failures="0" skipped="0" file="test.http" package="test.http" time="1.002">
+      <testcase name="status == 200" classname="test2" file="test.http" time="1.002" assertions="1"/>
     </testsuite>
   </testsuite>
   <testsuite name="test2.http" tests="1" failures="0" skipped="0" package="." time="1.002" file="test2.http">
-    <testsuite name="other" tests="1" failures="0" skipped="0" package="test2.http" time="1.002">
-      <testcase name="status == 200" assertions="1"/>
+    <testsuite name="other" tests="1" failures="0" skipped="0" file="test2.http" package="test2.http" time="1.002">
+      <testcase name="status == 200" classname="other" file="test2.http" time="1.002" assertions="1"/>
     </testsuite>
   </testsuite>
 </testsuites>
@@ -171,8 +171,8 @@ describe('transformToJunit', () => {
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="httpyac" tests="1" errors="0" disabled="1" failues="0" time="0.000">
   <testsuite name="test.http" tests="1" failures="0" skipped="1" package="." time="0.000" file="test.http">
-    <testsuite name="test" tests="1" failures="0" skipped="1" package="test.http" time="0.000">
-      <testcase name="skipped all tests">
+    <testsuite name="test" tests="1" failures="0" skipped="1" file="test.http" package="test.http" time="0.000">
+      <testcase name="skipped all tests" classname="test" time="0.000" file="test.http">
         <skipped/>
       </testcase>
     </testsuite>
@@ -228,14 +228,14 @@ describe('transformToJunit', () => {
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="httpyac" tests="2" errors="0" disabled="0" failues="1" time="0.000">
   <testsuite name="test.http" tests="2" failures="1" skipped="0" package="." time="0.000" file="test.http">
-    <testsuite name="test" tests="2" failures="1" skipped="0" package="test.http" time="0.000">
-      <testcase name="Assertions fail" assertions="1">
+    <testsuite name="test" tests="2" failures="1" skipped="0" file="test.http" package="test.http" time="0.000">
+      <testcase name="Assertions fail" classname="test" file="test.http" time="0.000" assertions="1">
         <properties>
           <property name="displayMessage" value="failed result"/>
         </properties>
         <failure message="Assertions fail" type="unknown">{"message":"test","name":"unknown","stack":""}</failure>
       </testcase>
-      <testcase name="status === 200" assertions="1"/>
+      <testcase name="status === 200" classname="test" file="test.http" time="0.000" assertions="1"/>
     </testsuite>
   </testsuite>
 </testsuites>
@@ -277,7 +277,7 @@ describe('transformToJunit', () => {
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="httpyac" tests="1" errors="0" disabled="0" failues="0" time="1.001">
   <testsuite name="test.http" tests="1" failures="0" skipped="0" package="." time="1.001" file="test.http">
-    <testsuite name="test" tests="1" failures="0" skipped="0" package="test.http" time="1.001">
+    <testsuite name="test" tests="1" failures="0" skipped="0" file="test.http" package="test.http" time="1.001">
       <properties>
         <property name="title" value="title"/>
       </properties>


### PR DESCRIPTION
the duration calculation for testCase assertions is totally a hack. Also the filename being relative to repo root allows gitlab to link to the file in the repo directly. 