### PR TITLE
Add support for basic auth with no password using colon syntax.

### DIFF
--- a/src/plugins/http/basicAuthVariableReplacer.ts
+++ b/src/plugins/http/basicAuthVariableReplacer.ts
@@ -6,7 +6,7 @@ export async function basicAuthVariableReplacer(text: unknown | undefined, type:
   if (type.toLowerCase() === 'authorization' && isString(text)) {
     const match = BasicAuthColon.exec(text) || BasicAuth.exec(text);
 
-    if (match && match.groups && match.groups.user && match.groups.password) {
+    if (match && match.groups && match.groups.user) {
       return `Basic ${Buffer.from(`${match.groups.user}:${match.groups.password}`).toString('base64')}`;
     }
   }

--- a/src/plugins/http/test/basicAuth.spec.ts
+++ b/src/plugins/http/test/basicAuth.spec.ts
@@ -18,4 +18,22 @@ authorization: Basic john doe
     expect(requests[0].headers?.authorization).toBe('Basic am9objpkb2U=');
     expect(requests[1].headers?.authorization).toBe('Basic am9objpkb2U=');
   });
+
+  it('basic auth with empty password', async () => {
+    initFileProvider();
+    const requests = initHttpClientProvider();
+    await sendHttp(
+      `
+GET  /json
+authorization: Basic john:
+
+###
+GET  /json
+authorization: Basic am9objo=
+    `
+    );
+
+    expect(requests[0].headers?.authorization).toBe('Basic am9objo=');
+    expect(requests[1].headers?.authorization).toBe('Basic am9objo=');
+  });
 });


### PR DESCRIPTION
If the password is not in the regex match, the function will not encode the header and instead return "Basic user:", which is what gets sent in the request.

Refs #751 