### PR TITLE
fix: return non-zero exit code for errored test

### DIFF
--- a/src/cli/send/plugin/testExitCodeInterceptor.ts
+++ b/src/cli/send/plugin/testExitCodeInterceptor.ts
@@ -12,10 +12,10 @@ export const testExitCodeInterceptor = {
 
   afterTrigger: async function bail(hookContext: HookTriggerContext<[models.ProcessorContext], boolean>) {
     const context = hookContext.args[0];
-    const hasFailedTestResult = context.httpRegion.testResults?.some?.(
-      obj => obj.status === models.TestResultStatus.FAILED
+    const hasFailedOrErroredTestResult = context.httpRegion.testResults?.some?.(
+      obj => obj.status === models.TestResultStatus.FAILED || obj.status === models.TestResultStatus.ERROR
     );
-    if (hasFailedTestResult) {
+    if (hasFailedOrErroredTestResult) {
       process.exitCode = 20;
     }
     return true;

--- a/src/cli/send/plugin/testExitCodeInterceptor.ts
+++ b/src/cli/send/plugin/testExitCodeInterceptor.ts
@@ -12,12 +12,30 @@ export const testExitCodeInterceptor = {
 
   afterTrigger: async function bail(hookContext: HookTriggerContext<[models.ProcessorContext], boolean>) {
     const context = hookContext.args[0];
-    const hasFailedOrErroredTestResult = context.httpRegion.testResults?.some?.(
-      obj => obj.status === models.TestResultStatus.FAILED || obj.status === models.TestResultStatus.ERROR
-    );
-    if (hasFailedOrErroredTestResult) {
+
+    if (context.httpRegion.testResults === undefined) {
+      return true;
+    }
+
+    let hasErroredTestResult = false;
+    let hasFailedTestResult = false;
+
+    for (const testResult of context.httpRegion.testResults) {
+      if (testResult.status === models.TestResultStatus.ERROR) {
+        hasErroredTestResult = true;
+        break;
+      }
+      if (testResult.status === models.TestResultStatus.FAILED) {
+        hasFailedTestResult = true;
+      }
+    }
+
+    if (hasErroredTestResult) {
+      process.exitCode = 19;
+    } else if (hasFailedTestResult) {
       process.exitCode = 20;
     }
+
     return true;
   },
 };


### PR DESCRIPTION
Fixes https://github.com/AnWeber/httpyac/issues/876.

Is this the right place to fix?
Should errored tests have a different non-zero exit code to failed tests?