### PR TITLE
fix: report invalid environment JSON

### DIFF
--- a/src/plugins/intellij/intellijVariableProvider.spec.ts
+++ b/src/plugins/intellij/intellijVariableProvider.spec.ts
@@ -73,5 +73,22 @@ describe('intellijVariableProvider', () => {
         foo: 'bar',
       });
     });
+    it.each(['http-client.env.json', 'http-client.private.env.json'])(
+      'should report invalid JSON in %s',
+      async fileName => {
+        initFileProvider({
+          [fileName]: '{"test":',
+        });
+
+        await expect(
+          provideIntellijVariables(['test'], {
+            httpFile: {
+              fileName: 'test.http',
+            },
+            variables: {},
+          } as VariableProviderContext)
+        ).rejects.toThrow(`Failed to parse environment file ${fileName}`);
+      }
+    );
   });
 });

--- a/src/plugins/intellij/intellijVariableProvider.ts
+++ b/src/plugins/intellij/intellijVariableProvider.ts
@@ -88,14 +88,16 @@ export async function provideIntellijVariables(
 }
 
 async function getEnvironmentVariables(fileName: PathLike): Promise<Record<string, Variables> | undefined> {
-  try {
-    if (await fileProvider.exists(fileName)) {
-      const content = await fileProvider.readFile(fileName, 'utf-8');
-      return JSON.parse(content);
-    }
-  } catch (err) {
-    log.trace(`${fileName} not found`);
-    log.trace(err);
+  if (!(await fileProvider.exists(fileName))) {
+    return undefined;
   }
-  return undefined;
+
+  const content = await fileProvider.readFile(fileName, 'utf-8');
+  try {
+    return JSON.parse(content);
+  } catch (err) {
+    throw new SyntaxError(
+      `Failed to parse environment file ${fileProvider.toString(fileName)}: ${utils.toString(err)}`
+    );
+  }
 }


### PR DESCRIPTION
Closes #939

## Summary

- keep missing IntelliJ environment files optional
- stop treating malformed existing environment files as missing
- report the failing file and original JSON parser message
- cover both `http-client.env.json` and `http-client.private.env.json`

## Testing

- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath src/plugins/intellij/intellijVariableProvider.spec.ts`
- `npm run eslint`
- `npm run tsc:check`
- `npm run build`
- `npm run lockfile-lint`
- `npm run packageJson-lint`
- `npx prettier --check src/plugins/intellij/intellijVariableProvider.ts src/plugins/intellij/intellijVariableProvider.spec.ts`

The full suite was also run locally: 46 of 56 suites passed. The remaining 10 failures are in unrelated Windows path and CRLF-sensitive fixture tests; the focused IntelliJ suite passes all 6 tests.
